### PR TITLE
Schemes und Redirections

### DIFF
--- a/classes/class.rex_yrewrite_scheme.inc.php
+++ b/classes/class.rex_yrewrite_scheme.inc.php
@@ -37,6 +37,11 @@ class rex_yrewrite_scheme
         return false;
     }
 
+    public function getRedirection(OOArticle $art)
+    {
+        return false;
+    }
+
     protected function normalize($string, $clang = 0)
     {
         $string = str_replace(

--- a/config.inc.php
+++ b/config.inc.php
@@ -115,8 +115,8 @@ if ($REX['MOD_REWRITE'] !== false && !$REX['SETUP']) {
         if ($REX['REDAXO']) {
             $extension = 'rex_yrewrite::generatePathFile';
             $extensionPoints = array(
-                'CAT_ADDED',   'CAT_UPDATED',   'CAT_DELETED',
-                'ART_ADDED',   'ART_UPDATED',   'ART_DELETED',
+                'CAT_ADDED',   'CAT_UPDATED',   'CAT_DELETED', 'CAT_STATUS',
+                'ART_ADDED',   'ART_UPDATED',   'ART_DELETED', 'ART_STATUS',
                 'CLANG_ADDED', 'CLANG_UPDATED', 'CLANG_DELETED',
                 /*'ARTICLE_GENERATED'*/
                 'ALL_GENERATED'


### PR DESCRIPTION
Hier nun ein Vorschlag, mit dem Plugins das URL-Schema ändern können.
- Plugins können eine eigene Scheme-Klasse erstellen und einhängen
- Die Standard-Klasse `rex_yrewrite_scheme` bildet 1:1 das alte "classic"-Scheme ab, "path" kann man erreichen, indem man [hier](https://github.com/gharlan/redaxo4_yrewrite/blob/schemes-and-redirections/classes/class.rex_yrewrite_scheme.inc.php#L5) das Suffix ändert.
- Über das Scheme lassen sich auch Artikel auf andere Artikel weiterleiten. Bei `rex_getUrl` bekommt man dann also direkt die URL zu dem weitergeleiteten Artikel.

So kann ich dann relativ einfach ein Scheme mit meinen speziellen Wünschen erstellen: https://github.com/gharlan/redaxo4_yrewrite/commit/dc53d34a8eaedccf60ed4dd99103368216802d14
Das unterscheidet sich vom Standard-Scheme durch zwei Punkte:
- Startartikel werden an den Pfad gehangen, falls die Kategorie noch weitere Artikel hat
- Kategorien mit Unterkategorien leiten direkt in die erste Unterkategorie weiter
