### PR TITLE
R5: Kategorien ignorieren

### DIFF
--- a/install.php
+++ b/install.php
@@ -12,6 +12,7 @@
 
 rex_sql_table::get('rex_article')
     ->ensureColumn(new rex_sql_column('yrewrite_url', 'varchar(255)'))
+    ->ensureColumn(new rex_sql_column('yrewrite_ignore_category', 'char(1)'))
     ->ensureColumn(new rex_sql_column('yrewrite_priority', 'varchar(5)'))
     ->ensureColumn(new rex_sql_column('yrewrite_changefreq', 'varchar(10)'))
     ->ensureColumn(new rex_sql_column('yrewrite_title', 'varchar(255)'))

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -6,7 +6,7 @@ yrewrite_rewriter_seo = SEO-Daten
 yrewrite_mode_url = URL
 yrewrite_mode_seo = SEO
 yrewrite_customurl = Benutzerdefinierte URL
-yrewrite_ignore_category = Do not use this category in the url
+yrewrite_ignore_category = Diese Kategorie nicht in die URL übernehmen
 yrewrite_update_url = URL aktualisieren
 yrewrite_update_seo = SEO-Daten aktualisieren
 

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -6,6 +6,7 @@ yrewrite_rewriter_seo = SEO-Daten
 yrewrite_mode_url = URL
 yrewrite_mode_seo = SEO
 yrewrite_customurl = Benutzerdefinierte URL
+yrewrite_ignore_category = Do not use this category in the url
 yrewrite_update_url = URL aktualisieren
 yrewrite_update_seo = SEO-Daten aktualisieren
 

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -6,6 +6,7 @@ yrewrite_rewriter_seo = SEO Data
 yrewrite_mode_url = URL
 yrewrite_mode_seo = SEO
 yrewrite_customurl = Custom URL
+yrewrite_ignore_category = Do not use this category in the url
 yrewrite_update = update URL
 
 yrewrite_domains = Domains

--- a/lib/scheme.php
+++ b/lib/scheme.php
@@ -36,7 +36,9 @@ class rex_yrewrite_scheme
      */
     public function appendCategory($path, rex_category $cat, rex_yrewrite_domain $domain)
     {
-        return $path . '/' . $this->normalize($cat->getName(), $cat->getClang());
+        $Sibling = $cat->getStartArticle()->getValue('yrewrite_ignore_category');
+        if($Sibling === '1') return $path;
+        return $path . '/' . $this->normalize(($Sibling?$Sibling:$cat->getName()), $cat->getClang());
     }
 
     /**

--- a/pages/content.yrewrite_url.php
+++ b/pages/content.yrewrite_url.php
@@ -73,6 +73,12 @@ if ($isStartarticle) {
         return $return;
     }, 'params'=>['article_id' => $article_id, "domain" => $domain, "clang" => $clang], 'message' => rex_i18n::msg('yrewrite_warning_urlexists')]);
 
+    /* Ursprüngliches Formular: hier muss noch eine Checkbox für die Kategorie eingefügt werden, damit die Kategorie ignoriert werden kann. */
+    // $n = [];
+    // $n['label'] = '';
+    // $n['field'] = '<div class="checkbox"><label class="control-label" for="rex-id-yrewrite-ignore-category"><input type="checkbox" id="rex-id-yrewrite-ignore-category" name="yrewrite_ignore_category" value="1"' . ($yrewrite_ignore_category == 1?' checked="checked"':'') . '" /> ' . $addon->i18n('ignore_category') . '</label></div>';
+    // $formElements[] = $n;
+    
     $yform->setActionField('db', [rex::getTable('article'), 'id=' . $article_id.' and clang_id='.$clang]);
     $yform->setObjectparams('submit_btn_label', $addon->i18n('update_url'));
     $form = $yform->getForm();


### PR DESCRIPTION
Ho!

Ich hab bei mir die Version 2.0-dev laufen und habe dort die hier aufgelisteten Änderungen vorgenommen. Für eure Version muss zumindest die URL-Page bearbeitet werden. 

Mit den Änderungen bekommt der User eine Checkbox, die eine Kategorie der URL ausschließt. Dass kann nützlich sein, wenn man eine Kategorie als Container verwendet - Footer | Header | Bereich eins | Bereich zwei ...
Damit können die Navigationen dann entsprechend generiert werden ohne dass hier Meta-Daten abgefragt werden müssen.

lg Sascha