### PR TITLE
Ungültige RewriteConditions entfernt, auch Aufrufe von existierenden …

### DIFF
--- a/setup/.htaccess
+++ b/setup/.htaccess
@@ -97,11 +97,8 @@ AddDefaultCharset utf-8
     RewriteRule ^imagetypes/([^/]*)/([^/]*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-l
-
-    RewriteCond %{REQUEST_URI} !^redaxo/.*
-    RewriteCond %{REQUEST_URI} !^media/.*
+    RewriteCond %{REQUEST_URI} !^/?redaxo/?$
 
     RewriteRule ^(.*)$ %{ENV:BASE}/index.php?%{QUERY_STRING} [L]
 


### PR DESCRIPTION
…Verzeichnissen ausser` /redaxo` werden umgeschrieben.

Bei einem aktuellen Projekt habe ich einen Hauptmenüpunkt "Media", die daraus resultierunde uri `http://domain.tld/media/` listete mir direkt den Inhalt des media-Verzeichnisses auf. Mir fällt ausser dem Backend kein Fall im Redaxo Kontext ein, in dem ich `RewriteCond %{REQUEST_FILENAME} !-d` bräuchte, deshalb habe ich das gelöscht und das Rewriting nur noch explizit für `/redaxo` deaktiviert Somit kann ich Hauptmenüpunkte so nennen wie ich lustig bin - abgesehen von "Redaxo" :)

`RewriteCond %{REQUEST_URI} !^redaxo/.*` und `RewriteCond %{REQUEST_URI} !^media/.*` haben imho noch nie funktioniert, deswegen habe ich sie ganz entfernt.