### PR TITLE
302 ergänzt

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -160,5 +160,6 @@ yrewrite_forward_domainurl_already_defined = Diese Domain/Url Kombination existi
 yrewrite_forward_move_method = Art der Weiterleitung
 
 yrewrite_forward_301 = 301 - Moved Permanently - dauerhafte Weiterleitung / alte Url existiert nicht mehr
+yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / normale Weiterleitung
 yrewrite_forward_307 = 307 - Temporary Redirect / vorübergehende Weiterleitung in Zukunft kann der Inhalt unter der aufgerufenen Url wieder zu finden sein

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -159,5 +159,6 @@ yrewrite_forward_domainurl_already_defined = This domain/Url combination exists 
 yrewrite_forward_move_method = Type of redirect
 
 yrewrite_forward_301 = 301 - Moved Permanently - old URL no longer exists
+yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / default redirect
 yrewrite_forward_307 = 307 - Temporary Redirect

--- a/lib/forward.php
+++ b/lib/forward.php
@@ -15,6 +15,7 @@ class rex_yrewrite_forward
 
     public static $movetypes = [
         '301' => '301 - Moved Permanently',
+        '302' => '302 - Found',
         '303' => '303 - See Other',
         '307' => '307 - Temporary Redirect',
     ];

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -44,7 +44,7 @@ if ($func != '') {
     $yform->setValidateField('size_range', ['url', 1, 255, $this->i18n('warning_nottolong')]);
     $yform->setValidateField('empty', ['url', $this->i18n('forward_enter_url')]);
     $yform->setValidateField('unique', ['domain_id,url', $this->i18n('forward_domainurl_already_defined')]);
-    $yform->setValueField('select', ['movetype', $this->i18n('forward_move_method'), $this->i18n('forward_301').'=301,'.$this->i18n('forward_303').'=303,'.$this->i18n('forward_307').'=307', '', '303']);
+    $yform->setValueField('select', ['movetype', $this->i18n('forward_move_method'), $this->i18n('forward_301').'=301,'.$this->i18n('forward_302').'=302,'.$this->i18n('forward_303').'=303,'.$this->i18n('forward_307').'=307', '', '303']);
     $yform->setValueField('select', ['type', $this->i18n('forward_type'), ''.$this->i18n('forward_type_article').'=article,'.$this->i18n('forward_type_extern').'=extern,'.$this->i18n('forward_type_media').'=media']);
 
     $yform->setValueField('html', ['', '<div id="rex-yrewrite-forward-article">']);


### PR DESCRIPTION
Es kommt vor, dass eine url nach einem Umzug vorhanden bleiben soll, aber erst später eine eigene Seite und eigene Inhalte bekommt. Es soll also keine Weiterleitung erfolgen, aber ein temporärer Inhalt unter der originalen url angezeigt werden. Das kann mit dieser zusätzlichen Auswahlmöglichkeit erfüllt werden. Daher wäre ich für eine Übernahme ausgesprochen dankbar :-)