### PR TITLE
Liste Weiterleitungen

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -159,6 +159,8 @@ yrewrite_forward_domainurl_already_defined = Diese Domain/Url Kombination existi
 
 yrewrite_forward_move_method = Art der Weiterleitung
 
+yrewrite_forward_movetype = Statuscode
+
 yrewrite_forward_301 = 301 - Moved Permanently - dauerhafte Weiterleitung / alte Url existiert nicht mehr
 yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / normale Weiterleitung

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -160,5 +160,6 @@ yrewrite_forward_domainurl_already_defined = Diese Domain/Url Kombination existi
 yrewrite_forward_move_method = Art der Weiterleitung
 
 yrewrite_forward_301 = 301 - Moved Permanently - dauerhafte Weiterleitung / alte Url existiert nicht mehr
+yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / normale Weiterleitung
 yrewrite_forward_307 = 307 - Temporary Redirect / vorübergehende Weiterleitung in Zukunft kann der Inhalt unter der aufgerufenen Url wieder zu finden sein

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -158,6 +158,8 @@ yrewrite_forward_domainurl_already_defined = This domain/Url combination exists 
 
 yrewrite_forward_move_method = Type of redirect
 
+yrewrite_forward_movetype = status code
+
 yrewrite_forward_301 = 301 - Moved Permanently - old URL no longer exists
 yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / default redirect

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -159,5 +159,6 @@ yrewrite_forward_domainurl_already_defined = This domain/Url combination exists 
 yrewrite_forward_move_method = Type of redirect
 
 yrewrite_forward_301 = 301 - Moved Permanently - old URL no longer exists
+yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / default redirect
 yrewrite_forward_307 = 307 - Temporary Redirect

--- a/lib/forward.php
+++ b/lib/forward.php
@@ -15,6 +15,7 @@ class rex_yrewrite_forward
 
     public static $movetypes = [
         '301' => '301 - Moved Permanently',
+        '302' => '302 - Found',
         '303' => '303 - See Other',
         '307' => '307 - Temporary Redirect',
     ];

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -130,10 +130,16 @@ jQuery(document).ready(function() {
 }
 
 if ($showlist) {
-    $sql = 'SELECT * FROM ' . rex::getTable('yrewrite_forward').' ORDER BY domain_id, url';
+    $sql = 'SELECT * FROM ' . rex::getTable('yrewrite_forward');
+    if (rex_get('sort','string') == 'domain_id') {
+        $sql .= ' ORDER BY url';
+        if (rex_get('sorttype','string') == 'desc') {
+            $sql .= ' DESC';
+        }
+    }
 
     $list = rex_list::factory($sql, 100);
-    $list->setColumnFormat('id', 'Id');
+//    $list->setColumnFormat('id', 'Id');
     $list->addParam('page', 'yrewrite/forward');
 
     $tdIcon = '<i class="fa fa-sitemap"></i>';
@@ -143,6 +149,9 @@ if ($showlist) {
 
     $list->setColumnParams('id', ['data_id' => '###id###', 'func' => 'edit']);
     $list->setColumnSortable('id');
+    $list->setColumnSortable('movetype');
+    $list->setColumnSortable('domain_id');
+    $list->setColumnSortable('status');
 
     $list->setColumnLabel('domain_id', $this->i18n('forward_url'));
     $list->setColumnFormat('domain_id', 'custom', function ($params) {
@@ -158,12 +167,14 @@ if ($showlist) {
     $list->removeColumn('url');
     $list->setColumnLabel('type', $this->i18n('forward_type'));
 
-    $list->removeColumn('id');
+    $list->setColumnLabel('movetype', $this->i18n('forward_type'));
+
+//    $list->removeColumn('id');
     $list->removeColumn('article_id');
     $list->removeColumn('clang');
     $list->removeColumn('extern');
     $list->removeColumn('media');
-    $list->removeColumn('movetype');
+//    $list->removeColumn('movetype');
     $list->removeColumn('domain');
 
     // $list->setColumnLabel('status', rex_i18n::msg('b_function'));

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -44,7 +44,7 @@ if ($func != '') {
     $yform->setValidateField('size_range', ['url', 1, 255, $this->i18n('warning_nottolong')]);
     $yform->setValidateField('empty', ['url', $this->i18n('forward_enter_url')]);
     $yform->setValidateField('unique', ['domain_id,url', $this->i18n('forward_domainurl_already_defined')]);
-    $yform->setValueField('select', ['movetype', $this->i18n('forward_move_method'), $this->i18n('forward_301').'=301,'.$this->i18n('forward_303').'=303,'.$this->i18n('forward_307').'=307', '', '303']);
+    $yform->setValueField('select', ['movetype', $this->i18n('forward_move_method'), $this->i18n('forward_301').'=301,'.$this->i18n('forward_302').'=302,'.$this->i18n('forward_303').'=303,'.$this->i18n('forward_307').'=307', '', '303']);
     $yform->setValueField('select', ['type', $this->i18n('forward_type'), ''.$this->i18n('forward_type_article').'=article,'.$this->i18n('forward_type_extern').'=extern,'.$this->i18n('forward_type_media').'=media']);
 
     $yform->setValueField('html', ['', '<div id="rex-yrewrite-forward-article">']);

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -167,7 +167,7 @@ if ($showlist) {
     $list->removeColumn('url');
     $list->setColumnLabel('type', $this->i18n('forward_type'));
 
-    $list->setColumnLabel('movetype', $this->i18n('forward_type'));
+    $list->setColumnLabel('movetype', $this->i18n('yrewrite_forward_movetype'));
 
 //    $list->removeColumn('id');
     $list->removeColumn('article_id');


### PR DESCRIPTION
Die Liste der Weiterleitungen wurde um den Statuscode ergänzt. Zusätzlich wurden die Sortierfunktionen über rex_list eingeschaltet. Damit kann man die Übersicht nach Statuscode, aktiv/inaktiv, url und id sortieren, was bei längeren Weiterleitungsliste erhebliche Vorteile bei der Bearbeitung bringt.