### PR TITLE
Use DIRECTORY_SEPARATOR when creating the path with dirname

### DIFF
--- a/lib/yrewrite.php
+++ b/lib/yrewrite.php
@@ -44,7 +44,7 @@ class rex_yrewrite
         if (rex::isBackend()) {
             $path = dirname($path);
         }
-        $path = rtrim($path, '/') . '/';
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . '/';
         self::addDomain(new rex_yrewrite_domain('default', null, $path, 0, rex_article::getSiteStartArticleId(), rex_article::getNotfoundArticleId()));
 
         self::$pathfile = rex_path::addonCache('yrewrite', 'pathlist.json');


### PR DESCRIPTION
On Windows under certain circumstances YRewrite generates invalid URLs such as `http://my-domain.localhost\/page`. This is because 

        $path = dirname($_SERVER['SCRIPT_NAME']);
        if (rex::isBackend()) {
            $path = dirname($path);
        }
        $path = rtrim($path, '/') . '/';

will not remove the final `\` that is part of the path returned from dirname. Using the locale `DIRECTORY_SEPARATOR` the issue can be resolved.