### PR TITLE
Falls eine Sprache gelöscht wurde...

### DIFF
--- a/pages/domains.php
+++ b/pages/domains.php
@@ -136,7 +136,9 @@ if ($showlist) {
         } else {
             $return = [];
             foreach (explode(',', $clangs) as $clang) {
-                $return[] = rex_clang::get($clang)->getName();
+            	if(rex_clang::get($clang)) {
+                	$return[] = rex_clang::get($clang)->getName();
+                }
             }
             if (count($return) > 1) {
                 $return = implode(',', $return) . '<br />'.$this->i18n('clang_start').': '.rex_clang::get($params['list']->getValue('clang_start'))->getName();


### PR DESCRIPTION
Wenn eine Sprache gelöscht wird und dann YRewrite aufgerufen wird, gibt es einen fatal error. Grund: in der Datenbank ist im Feld "clangs" noch die gelöschte Sprache hinterlegt. Dieser Fix löst das Problem.