### PR TITLE
Indizierung -> Indexierung

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -98,10 +98,10 @@ yrewrite_changefreq_yearly = jährlich [yearly]
 yrewrite_changefreq_never = nie [never]
 yrewrite_changefreq_always = immer [always]
 
-yrewrite_index = Indizierung und Sitemap
-yrewrite_index_status = In Abhängigkeit von Status Indizierung erlauben und in Sitemap anzeigen
-yrewrite_index_index = Indizierung erlauben / in Sitemap anzeigen (Index)
-yrewrite_index_noindex = Indizierung verbieten / nicht in Sitemap anzeigen (NoIndex)
+yrewrite_index = Indexierung und Sitemap
+yrewrite_index_status = In Abhängigkeit von Status Indexierung erlauben und in Sitemap anzeigen
+yrewrite_index_index = Indexierung erlauben / in Sitemap anzeigen (Index)
+yrewrite_index_noindex = Indexierung verbieten / nicht in Sitemap anzeigen (NoIndex)
 
 yrewrite_htaccess_hasbeenset = .htaccess Datei wurde gesetzt/ersetzt
 yrewrite_htaccess_set = .htaccess Datei setzen


### PR DESCRIPTION
https://www.duden.de/rechtschreibung/indexieren
(Fachsprache) einen Index (1), eine Liste von Gegenständen oder Hinweisen anlegen

https://www.duden.de/rechtschreibung/indizieren
(ein Druckwerk) in eine Liste von Schriften aufnehmen, deren Verbreitung an Jugendliche untersagt ist, weil sie als jugendgefährdend gelten

siehe auch: https://de.wikipedia.org/wiki/Indexierung

Muss m.E. nicht in YTraduco neu übersetzt werden, da nur die dt. Übersetzung falsch ist.