### PR TITLE
HTML Tags entfernen

### DIFF
--- a/lib/scheme.php
+++ b/lib/scheme.php
@@ -127,7 +127,7 @@ class rex_yrewrite_scheme
         $string = str_replace(
             ['Ä',  'Ö',  'Ü',  'ä',  'ö',  'ü',  'ß',  'À', 'à', 'Á', 'á', 'ç', 'È', 'è', 'É', 'é', 'ë', 'Ì', 'ì', 'Í', 'í', 'Ï', 'ï', 'Ò', 'ò', 'Ó', 'ó', 'ô', 'Ù', 'ù', 'Ú', 'ú', 'Č', 'č', 'Ł', 'ł', 'ž', '/', '®', '©', '™'],
             ['Ae', 'Oe', 'Ue', 'ae', 'oe', 'ue', 'ss', 'A', 'a', 'A', 'a', 'c', 'E', 'e', 'E', 'e', 'e', 'I', 'i', 'I', 'i', 'I', 'i', 'O', 'o', 'O', 'o', 'o', 'U', 'u', 'U', 'u', 'C', 'c', 'L', 'l', 'z', '-', '',  '',  ''],
-            $string
+            strip_tags($string)
         );
         $string = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $string);
         $string = preg_replace('/[^\w -]+/', '', $string);


### PR DESCRIPTION
Auf was für Ideen Kunden kommen: sie schreiben HTML Tags in die Kategorie- und Artikelnamen. Hiermit bleibt eine schöne URL erhalten. (In der seo Klasse ist das schon so umgesetzt: https://github.com/yakamara/redaxo_yrewrite/blob/2e1a454d070b2694303fa73aa89dd84fd263d0e2/lib/seo.php#L41)