### PR TITLE
utf8mb4 Umstellung

### DIFF
--- a/install.php
+++ b/install.php
@@ -61,4 +61,9 @@ $table
     ->ensureColumn(new rex_sql_column('expiry_date', 'date'))
     ->ensure();
 
+$c = rex_sql::factory();
+$c->setQuery('ALTER TABLE `' . rex::getTable('yrewrite_domain') . '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+$c->setQuery('ALTER TABLE `' . rex::getTable('yrewrite_alias') . '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+$c->setQuery('ALTER TABLE `' . rex::getTable('yrewrite_forward') . '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');
+
 rex_delete_cache();


### PR DESCRIPTION
Wenn ich einen Artikel mit chinesischen Zeichen in YRewrite 2.5 umbennen und eine Weiterleitung automatisch angelegt werden soll erhalte ich folgenden Fehler:

PDOException: SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (utf8_general_ci,IMPLICIT) and (utf8mb4_general_ci,COERCIBLE) for operation '=' in /www/htdocs/redaxo/src/core/lib/sql/sql.php:296 Stack trace: #0 /www/htdocs/redaxo/src/core/lib/sql/sql.php(296): PDOStatement->execute(Array) #1 /www/htdocs/redaxo/src/core/lib/sql/sql.php(341): rex_sql->execute(Array, Array) #2 /www/htdocs/redaxo/src/core/lib/sql/sql.php(938): rex_sql->setQuery('DELETE FROM `re...', Array) #3 /www/htdocs/redaxo/src/addons/yrewrite/lib/yrewrite.php(605): rex_sql->delete() #4 /www/htdocs/redaxo/src/addons/yrewrite/boot.php(44): rex_yrewrite::generatePathFile(Array) #5 /www/htdocs/redaxo/src/core/lib/extension.php(45): rex_package->{closure}(Object(rex_extension_point)) #6 /www/htdocs/redaxo/src/addons/structure/lib/service_article.php(205): rex_extension::registerPoint(Object(rex_extension_point)) #7 /www/htdocs/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php(26): rex_article_service::editArticle(1113, 11, Array) #8 /www/htdocs/redaxo/src/core/lib/api_function.php(178): rex_api_article_edit->execute() #9 /www/htdocs/redaxo/src/core/backend.php(151): rex_api_function::handleCall() #10 /www/htdocs/redaxo/src/core/boot.php(136): require('/www/htdocs/w01...') #11 /www/htdocs/redaxo/index.php(9): require('/www/htdocs/w01...') #12 {main} Next rex_sql_exception: Error while executing statement "DELETE FROM `rex_yrewrite_forward` WHERE `url` = :url" using params ! SQLSTATE[HY000]: General error: 1267 Illegal mix of collations (utf8_general_ci,IMPLICIT) and (utf8mb4_general_ci,COERCIBLE) for operation '=' in /www/htdocs/redaxo/src/core/lib/sql/sql.php:299 Stack trace: #0 /www/htdocs/redaxo/src/core/lib/sql/sql.php(341): rex_sql->execute(Array, Array) #1 /www/htdocs/redaxo/src/core/lib/sql/sql.php(938): rex_sql->setQuery('DELETE FROM `re...', Array) #2 /www/htdocs/redaxo/src/addons/yrewrite/lib/yrewrite.php(605): rex_sql->delete() #3 /www/htdocs/redaxo/src/addons/yrewrite/boot.php(44): rex_yrewrite::generatePathFile(Array) #4 /www/htdocs/redaxo/src/core/lib/extension.php(45): rex_package->{closure}(Object(rex_extension_point)) #5 /www/htdocs/redaxo/src/addons/structure/lib/service_article.php(205): rex_extension::registerPoint(Object(rex_extension_point)) #6 /www/htdocs/redaxo/src/addons/structure/lib/api_functions/api_article_edit.php(26): rex_article_service::editArticle(1113, 11, Array) #7 /www/htdocs/redaxo/src/core/lib/api_function.php(178): rex_api_article_edit->execute() #8 /www/htdocs/redaxo/src/core/backend.php(151): rex_api_function::handleCall() #9 /www/htdocs/redaxo/src/core/boot.php(136): require('/www/htdocs/w01...') #10 /www/htdocs/redaxo/index.php(9): require('/www/htdocs/w01...') #11 {main}

Der Fix behebt den Fehler. Er ist aus YForm entlehnt.