### PR TITLE
select_sql entfernt

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -19,4 +19,4 @@ requires:
     redaxo: '^5.5'
     packages:
         structure: '^2.0'
-        yform/manager: '>2,<4'
+        yform/manager: '^3.0'

--- a/pages/domains.php
+++ b/pages/domains.php
@@ -37,8 +37,8 @@ if ($func != '') {
     $yform->setValueField('be_link', ['notfound_id', $this->i18n('notfound_id'), 'notice' => '<small>'.$this->i18n('notfound_info').'</small>']);
     $yform->setValidateField('empty', ['notfound_id', $this->i18n('no_not_found_id_defined')]);
 
-    $yform->setValueField('select_sql', ['clangs', $this->i18n('clangs'), 'select id,name from '.rex::getTable('clang'), '', 1, 0, '', 1, rex_clang::count(), 'notice' => '<small>'.$this->i18n('clangs_info').'</small>']);
-    $yform->setValueField('select_sql', ['clang_start', $this->i18n('clang_start'), 'select id,name from '.rex::getTable('clang').' order by id', 'notice' => '<small>'.$this->i18n('clang_start_info').'</small>']);
+    $yform->setValueField('choice', ['clangs', $this->i18n('clangs'), 'select id, name from '.rex::getTable('clang'), 0, 1, '', '', '', '', '', '', '', '<small>'.$this->i18n('clangs_info').'</small>']);
+    $yform->setValueField('choice', ['clang_start', $this->i18n('clang_start'), 'select id, name from '.rex::getTable('clang'), 0, 0, '', '', '', '', '', '', '', '<small>'.$this->i18n('clang_start_info').'</small>']);
     $yform->setValueField('checkbox', ['clang_start_hidden', $this->i18n('clang_start_hidden')]);
     $yform->setValueField('text', ['title_scheme', $this->i18n('domain_title_scheme'),rex_yrewrite_seo::$title_scheme_default, 'notice' => '<small>'.$this->i18n('domain_title_scheme_info').'</small>'] );
     $yform->setValueField('checkbox', ['auto_redirect', $this->i18n('auto_redirects'), 'notice' => '<small>'.$this->i18n('yrewrite_auto_redirect').'</small>']);


### PR DESCRIPTION
Die beiden select_sql Felder wurden durch Choice Felder ersetzt. Grund. Die Mehrfahrauswahl des "clangs" Feldes wurden mit YForm 3 nicht mehr gespeichert.