### PR TITLE
Kategorie `media` und Subkategorien ermöglichen

### DIFF
--- a/setup/.htaccess
+++ b/setup/.htaccess
@@ -93,8 +93,8 @@ AddDefaultCharset utf-8
 
     # REWRITE RULE FOR SEO FRIENDLY IMAGE MANAGER URLS
     RewriteRule ^mediatypes/([^/]*)/([^/]*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2
-    RewriteRule ^media/([^/]+)/(.*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]
-    RewriteRule ^media/(.*) %{ENV:BASE}/index.php?rex_media_type=default&rex_media_file=$1&%{QUERY_STRING} [B]
+    RewriteRule ^media\/([^\/]+)\/(.+)[^\/] %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]
+    RewriteRule ^media/(.+)[^\/] %{ENV:BASE}/index.php?rex_media_type=default&rex_media_file=$1&%{QUERY_STRING} [B]
 
     # deprecated
     RewriteRule ^images/([^/]*)/([^/]*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]

--- a/setup/.htaccess
+++ b/setup/.htaccess
@@ -93,8 +93,8 @@ AddDefaultCharset utf-8
 
     # REWRITE RULE FOR SEO FRIENDLY IMAGE MANAGER URLS
     RewriteRule ^mediatypes/([^/]*)/([^/]*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2
-    RewriteRule ^media\/([^\/]+)\/(.+)[^\/] %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]
-    RewriteRule ^media/(.+)[^\/] %{ENV:BASE}/index.php?rex_media_type=default&rex_media_file=$1&%{QUERY_STRING} [B]
+    RewriteRule ^media/([^/]+)/(.+)[^/] %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]
+    RewriteRule ^media/(.+)[^/] %{ENV:BASE}/index.php?rex_media_type=default&rex_media_file=$1&%{QUERY_STRING} [B]
 
     # deprecated
     RewriteRule ^images/([^/]*)/([^/]*) %{ENV:BASE}/index.php?rex_media_type=$1&rex_media_file=$2&%{QUERY_STRING} [B]


### PR DESCRIPTION
In der Standardkonfiguration von YForm ohne eigenes Schema lässt sich durch geschicktere Formulierung der Regex auch Kategorien und Subkategorien ermöglichen: Nämlich durch Prüfen, ob die Anfrage am Ende ein `/` enthält. Der Media Manager soll nur URLs prüfen, die kein Slash am Ende haben, z.B. `media/file.ext` oder `media/type/file.ext`, nicht jedoch `media/` oder `media/category/`