### PR TITLE
Windows Rechnern ermöglichen, dass die "default"-domain funktioniert

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -44,7 +44,7 @@ class rex_yrewrite
         if (rex::isBackend()) {
             $path = dirname($path);
         }
-        $path = rtrim($path, '/') . '/';
+        $path = rtrim($path, DIRECTORY_SEPARATOR) . '/';
         self::addDomain(new rex_yrewrite_domain('default', null, $path, 0, rex_article::getSiteStartArticleId(), rex_article::getNotfoundArticleId()));
 
         self::$pathfile = rex_path::addonCache('yrewrite', 'pathlist.json');


### PR DESCRIPTION
Im Moment erzeugt mir yrewrite ohne eingetragene domain (also mit der "default") auf meinem Windows-Rechner Links der Form `http://abcd.local\/`

Im Fix nutze ich "DIRECTORY_SEPARATOR" im rtrim.
Das ist die letzte Stelle, wo ein Dateipfad genutzt wird - alles andere sind URLs. Da reicht den slash rausfiltern. An einer anderen Stelle ist auch die Konstante im Einsatz.