### PR TITLE
Auch im Backend Domain-Aliase umleiten

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -60,8 +60,7 @@ rex_extension::register('PACKAGES_INCLUDED', function ($params) {
         return rex_yrewrite::rewriteMedia($ep->getParams());
     });
 
-    if (!rex::isBackend()) {
-        // get ARTICLE_ID from URL
+    if (!rex::getConsole()) {
         rex_yrewrite::prepare();
     }
 

--- a/boot.php
+++ b/boot.php
@@ -60,7 +60,7 @@ rex_extension::register('PACKAGES_INCLUDED', function ($params) {
         return rex_yrewrite::rewriteMedia($ep->getParams());
     });
 
-    if (!rex::getConsole()) {
+    if ('cli' !== PHP_SAPI) {
         rex_yrewrite::prepare();
     }
 

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -296,7 +296,11 @@ class rex_yrewrite
 
         $currentScheme = self::isHttps() ? 'https' : 'http';
         $domainScheme = $domain->getScheme();
-        if ($domainScheme && $domainScheme !== $currentScheme) {
+        if (
+            $domainScheme && $domainScheme !== $currentScheme &&
+            // do not redirect to http in backend if core config use_https is true
+            (!rex::isBackend() || 'https' === $domainScheme || !rex::getProperty('use_https'))
+        ) {
             header('HTTP/1.1 301 Moved Permanently');
             header('Location: ' . $domainScheme . '://' . $host . $url . $params);
             exit;

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -247,7 +247,7 @@ class rex_yrewrite
 
         $host = self::getHost();
 
-        if (isset(self::$paths['paths'][$host])) {
+        if (isset(self::$domainsByName[$host])) {
             $domain = self::$domainsByName[$host];
         } else {
             // check for aliases
@@ -300,6 +300,10 @@ class rex_yrewrite
             header('HTTP/1.1 301 Moved Permanently');
             header('Location: ' . $domainScheme . '://' . $host . $url . $params);
             exit;
+        }
+
+        if (rex::isBackend()) {
+            return true;
         }
 
         if (0 === strpos($url, $domain->getPath())) {

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -296,7 +296,11 @@ class rex_yrewrite
 
         $currentScheme = self::isHttps() ? 'https' : 'http';
         $domainScheme = $domain->getScheme();
-        if ($domainScheme && $domainScheme !== $currentScheme && !rex::getProperty('use_https')) {
+        $coreUseHttps = rex::getProperty('use_https');
+        if (
+            $domainScheme && $domainScheme !== $currentScheme &&
+            true !== $coreUseHttps && rex::getEnvironment() !== $coreUseHttps
+        ) {
             header('HTTP/1.1 301 Moved Permanently');
             header('Location: ' . $domainScheme . '://' . $host . $url . $params);
             exit;

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -296,11 +296,7 @@ class rex_yrewrite
 
         $currentScheme = self::isHttps() ? 'https' : 'http';
         $domainScheme = $domain->getScheme();
-        if (
-            $domainScheme && $domainScheme !== $currentScheme &&
-            // do not redirect to http in backend if core config use_https is true
-            (!rex::isBackend() || 'https' === $domainScheme || !rex::getProperty('use_https'))
-        ) {
+        if ($domainScheme && $domainScheme !== $currentScheme && !rex::getProperty('use_https')) {
             header('HTTP/1.1 301 Moved Permanently');
             header('Location: ' . $domainScheme . '://' . $host . $url . $params);
             exit;


### PR DESCRIPTION
closes #325

Mit diesem PR greifen im Backend sowohl die expliziten Alias-Domains, als auch die impliziten Umleitungen zwischen http und https, bzw. www und non-www.

@dergel Nicht blind mergen, sondern auch nochmal drüber nachdenken, ob es so passt.
Bei meinen lokalen Tests sah es aber gut aus.