### PR TITLE
Seo Option 'noindex,follow'

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -104,6 +104,7 @@ yrewrite_index = Indexierung und Sitemap
 yrewrite_index_status = In Abhängigkeit von Status Indexierung erlauben und in Sitemap anzeigen
 yrewrite_index_index = Indexierung erlauben / in Sitemap anzeigen (Index)
 yrewrite_index_noindex = Indexierung verbieten / nicht in Sitemap anzeigen (NoIndex)
+yrewrite_index_noindex_follow = Indexierung verbieten und Links folgen / nicht in Sitemap anzeigen (NoIndex)
 
 yrewrite_htaccess_hasbeenset = .htaccess Datei wurde gesetzt/ersetzt
 yrewrite_htaccess_set = .htaccess Datei setzen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -104,6 +104,7 @@ yrewrite_index = Search Engine Index and Sitemap
 yrewrite_index_status = Status controls Index and Sitemap
 yrewrite_index_index = allow Search Engine to index page / display in Sitemap (Index)
 yrewrite_index_noindex = do not allow Search Engine to index page / do not display in Sitemap (NoIndex)
+yrewrite_index_noindex_follow = do not allow Search Engine to index page and follow its links / do not display in Sitemap (NoIndex)
 
 yrewrite_htaccess_hasbeenset = .htaccess file has been created or overwritten
 yrewrite_htaccess_set = Set .htaccess file

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -104,6 +104,7 @@ yrewrite_index = Indexación y mapa del sitio
 yrewrite_index_status = Según el estado, permita indexar y ver en el mapa del sitio
 yrewrite_index_index = Permitir indexación / Mostrar mapa del sitio (índice)
 yrewrite_index_noindex = Prohibir indexación / no mostrar en Sitemap (NoIndex)
+yrewrite_index_noindex_follow = Prohibir indexación y seguir enlaces / no mostrar en Sitemap (NoIndex)
 
 yrewrite_htaccess_hasbeenset = El archivo .htaccess fue establecido/reemplazado
 yrewrite_htaccess_set = Establecer archivo .htaccess

--- a/lang/pt_br.lang
+++ b/lang/pt_br.lang
@@ -101,6 +101,7 @@ yrewrite_index = Indexação e sitemap
 yrewrite_index_status = Autorizar dependendo da indexação status e exibi-los no Sitemap
 yrewrite_index_index = Permitir indexação / Mapa do site (Índice)
 yrewrite_index_noindex = Proibir indexação / exibir no Sitemap (noindex)
+yrewrite_index_noindex_follow = Proibir indexação e seguir links / exibir no Sitemap (noindex)
 
 yrewrite_htaccess_hasbeenset = Arquivo .htaccess foi criado/substituído
 yrewrite_htaccess_set = Definir arquivo .htaccess

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -104,6 +104,7 @@ yrewrite_index = Sökmotorindex och webbplatskarta (sitemap)
 yrewrite_index_status = Status controls Index and Sitemap
 yrewrite_index_index = Tillåter indexering / visa i sitemap (index)
 yrewrite_index_noindex = Tillåta inte indexering sida / visa inte i sitemap (NoIndex)
+yrewrite_index_noindex_follow = Tillåta inte indexering sida och följ länkar / visa inte i sitemap (NoIndex)
 
 yrewrite_htaccess_hasbeenset = .htaccess-filen har skapats eller skrivits över
 yrewrite_htaccess_set = skapa .htaccess fil

--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -80,6 +80,8 @@ class rex_yrewrite_seo
     {
         if ($this->article->getValue(self::$meta_index_field) == 1 || ($this->article->getValue(self::$meta_index_field) == 0 && $this->article->isOnline())) {
             return '<meta name="robots" content="index, follow">';
+        } else if ($this->article->getValue(self::$meta_index_field) == 2) {
+            return '<meta name="robots" content="noindex, follow">';
         } else {
             return '<meta name="robots" content="noindex, nofollow">';
         }

--- a/pages/content.yrewrite_seo.php
+++ b/pages/content.yrewrite_seo.php
@@ -32,6 +32,7 @@ $index_setting = [];
 $index_setting[] = rex_i18n::msg('yrewrite_index_status').'=0';
 $index_setting[] = rex_i18n::msg('yrewrite_index_index').'=1';
 $index_setting[] = rex_i18n::msg('yrewrite_index_noindex').'=-1';
+$index_setting[] = rex_i18n::msg('yrewrite_index_noindex_follow').'=2';
 
 $yform = new rex_yform();
 $yform->setObjectparams('form_action', rex_url::backendController(['page' => 'content/edit', 'article_id' => $article_id, 'clang' => $clang, 'ctype' => $ctype], false));


### PR DESCRIPTION
Seo Option '<.meta name="robots" content="noindex, follow">' hinzugefügt.
(der Punkt vor Meta weil sonst als HTML gerendert)

Dazu kein Eintrag in sitemap.xml.

Übersetzungen aus vorhandenen Einträgen und Google Translate.

Meta Tag und Sitemap wurden getestet.