### PR TITLE
Auch bei nur einer Sprache diese mit in URL (wenn clang_start_hidden=0)

### DIFF
--- a/lib/yrewrite/scheme.php
+++ b/lib/yrewrite/scheme.php
@@ -36,7 +36,7 @@ class rex_yrewrite_scheme
      */
     public function getClang($clang, rex_yrewrite_domain $domain)
     {
-        if (count($domain->getClangs()) <= 1 || $domain->isStartClangHidden() && $clang == $domain->getStartClang()) {
+        if ($domain->isStartClangHidden() && $clang == $domain->getStartClang()) {
             return '';
         }
 

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yrewrite
-version: '2.6'
+version: '2.7-dev'
 author: Jan Kristinus, Gregor Harlan
 supportpage: www.redaxo.org/de/forum/
 docspage: https://github.com/yakamara/redaxo_yrewrite/edit/master/README.md

--- a/update.php
+++ b/update.php
@@ -39,3 +39,17 @@ if (rex_string::versionCompare($this->getVersion(), '2.1', '<=')) {
     rex_delete_cache();
 }
 
+if (rex_string::versionCompare($this->getVersion(), '2.7-dev', '<=')) {
+    $where = 'clangs NOT LIKE "%,%"';
+    if (rex_clang::count() > 1) {
+        $where = 'clangs != "" AND '.$where;
+    }
+
+    rex_sql::factory()
+        ->setTable(rex::getTable('yrewrite_domain'))
+        ->setWhere($where)
+        ->setValue('start_clang_hidden', 1)
+        ->update();
+
+    rex_yrewrite::deleteCache();
+}


### PR DESCRIPTION
Aktuell ist es so, dass wenn nur eine Sprache existiert, oder nur eine Sprache für eine Domain ausgewählt wurde, die Checkbox "Startsprache nicht mit in URL" keine Auswirkung hat, die Startsprache ist dann niemals mit in der URL.

Ich schlage vor es so zu ändern, dass auch dann die Checkbox eine Auswirkung hat. So kann man auch bei nur einer Sprache diese mit in die URL bekommen, zum Beispiel als Vorplanung, falls irgendwann weitere Sprachen hinzukommen.

Beim Update werden alle vorhandenen Domains entsprechend angepasst, damit sie sich genauso verhalten, wie vorher.