### PR TITLE
Bei Artikeln aus Default-Domain relative URLs erzeugen

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -409,7 +409,8 @@ class rex_yrewrite
             foreach ((array) self::$paths['paths'] as $i_domain => $i_id) {
                 if (isset(self::$paths['paths'][$i_domain][$id][$clang])) {
                     $domain = self::getDomainByName($i_domain);
-                    $path = $domain->getUrl() . self::$paths['paths'][$i_domain][$id][$clang];
+                    $path = 'default' === $domain->getName() ? $domain->getPath() : $domain->getUrl();
+                    $path .= self::$paths['paths'][$i_domain][$id][$clang];
                     break;
                 }
             }


### PR DESCRIPTION
Die bleiben ja sowieso auf der aktuellen Domain.

Ist nötig als Fix für https://github.com/redaxo/redaxo/issues/3681. Ansonsten wurde [hier](https://github.com/redaxo/redaxo/blob/afb1650b13b81235a7236ab838e216882dca917d/redaxo/src/addons/structure/plugins/history/boot.php#L34) immer ausgeloggt, wenn man in yrewrite keine Domain angelegt hat.