### PR TITLE
Korrigiert bei Domains mit subfolder die Sitemap

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -731,10 +731,11 @@ class rex_yrewrite
     {
         $domain = self::getHost();
         $http = 'http://';
+        $subfolder = rex_url::base();
         if (self::isHttps()) {
             $http = 'https://';
         }
-        return $http . $domain . '/' . $link;
+        return $http . $domain . $subfolder . $link;
     }
 
     public static function getHost()


### PR DESCRIPTION
Bei Domains mit subfolder wurde die sitemap.xml nicht richtig generiert:

Dieser Fix behebt das Problem #306