### PR TITLE
Optional Unicode-URLs unterstützen

### DIFF
--- a/install.php
+++ b/install.php
@@ -77,7 +77,7 @@ $c->setQuery('ALTER TABLE `' . rex::getTable('yrewrite_forward') . '` CONVERT TO
 
 rex_delete_cache();
 
-if (!class_exists('rex_yrewrite_seo_visibility')) {
-    require_once('lib/yrewrite/seo_visibility.php');
+if (!class_exists('rex_yrewrite_settings')) {
+    require_once('lib/yrewrite/settings.php');
 }
-rex_yrewrite_seo_visibility::install();
+rex_yrewrite_settings::install();

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -179,7 +179,8 @@ yrewrite_expiry_date = Deaktivierungsdatum
 
 yrewrite_perm_url_edit = YRewrite: URL editieren
 yrewrite_perm_seo_edit = YRewrite: SEO-Daten editieren
-yrewrite_seo_settings = Einstellungen
-yrewrite_seo_saved = Einstellungen gespeichert
+yrewrite_settings = Einstellungen
+yrewrite_settings_saved = Einstellungen gespeichert
+yrewrite_unicode_urls = Unicode-Zeichen in URLs erlauben (Umlaute, chinesische/kyrillische Zeichen etc.)
 yrewrite_hide_url_block = URL-Block verbergen
 yrewrite_hide_seo_block = SEO-Block verbergen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -179,7 +179,8 @@ yrewrite_expiry_date = Date of deactivation
 
 yrewrite_perm_url_edit = Yrewrite: URL editing
 yrewrite_perm_seo_edit = Yrewrite: SEO-Data editing
-yrewrite_seo_settings = Settings
-yrewrite_seo_saved = Settings updated
+yrewrite_settings = Settings
+yrewrite_settings_saved = Settings updated
+yrewrite_unicode_urls = Allow unicode chars in URLs (umlauts, chinese/cyrillic characters etc.)
 yrewrite_hide_url_block = Hide URL-Block
 yrewrite_hide_seo_block = Hide SEO-Block

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -175,7 +175,7 @@ yrewrite_expiry_date = fecha de desactivación
 
 yrewrite_perm_url_edit = Yrewrite: Edición de URL
 yrewrite_perm_seo_edit = Yrewrite: Edición de datos SEO
-yrewrite_seo_settings = Ajustes
-yrewrite_seo_saved = Configuraciones guardadas
+yrewrite_settings = Ajustes
+yrewrite_settings_saved = Configuraciones guardadas
 yrewrite_hide_url_block = Ocultar bloque de URL
 yrewrite_hide_seo_block = Ocultar bloque SEO

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -175,7 +175,7 @@ yrewrite_expiry_date = Avaktiveringsdatum
 
 yrewrite_perm_url_edit = Yrewrite: redigera URL
 yrewrite_perm_seo_edit = Yrewrite: redigera SEO-data
-yrewrite_seo_settings = Inställningar
-yrewrite_seo_saved = Inställningar sparades
+yrewrite_settings = Inställningar
+yrewrite_settings_saved = Inställningar sparades
 yrewrite_hide_url_block = Dölj URL-block
 yrewrite_hide_seo_block = Dölj SEO-block

--- a/lib/yrewrite/scheme.php
+++ b/lib/yrewrite/scheme.php
@@ -127,6 +127,13 @@ class rex_yrewrite_scheme
      */
     public function normalize($string, $clang = 1)
     {
+        if (rex_addon::get('yrewrite')->getConfig('unicode_urls')) {
+            $string = str_replace(["'", '’', 'ʻ'], '', $string);
+            $string = preg_replace('/[^\p{L&}\p{Lo}\p{M}\p{N}\p{Sc}]+/u', '-', $string);
+            $string = mb_strtolower(trim($string, '-'));
+            return $string;
+        }
+
         $string = str_replace(
             ['Ä',  'Ö',  'Ü',  'ä',  'ö',  'ü',  'ß',  'À', 'à', 'Á', 'á', 'ç', 'È', 'è', 'É', 'é', 'ë', 'Ì', 'ì', 'Í', 'í', 'Ï', 'ï', 'Ò', 'ò', 'Ó', 'ó', 'ô', 'Ù', 'ù', 'Ú', 'ú', 'Č', 'č', 'Ł', 'ł', 'ž', '/', '®', '©', '™'],
             ['Ae', 'Oe', 'Ue', 'ae', 'oe', 'ue', 'ss', 'A', 'a', 'A', 'a', 'c', 'E', 'e', 'E', 'e', 'e', 'I', 'i', 'I', 'i', 'I', 'i', 'O', 'o', 'O', 'o', 'o', 'U', 'u', 'U', 'u', 'C', 'c', 'L', 'l', 'z', '-', '',  '',  ''],

--- a/lib/yrewrite/settings.php
+++ b/lib/yrewrite/settings.php
@@ -6,7 +6,7 @@
  * @package redaxo\yrewrite
  */
 
-class rex_yrewrite_seo_visibility
+class rex_yrewrite_settings
 {
     /**
      * @return rex_addon
@@ -27,10 +27,13 @@ class rex_yrewrite_seo_visibility
 
         // Process form data
         if (rex_post('submit', 'boolean')) {
+            $addon->setConfig('unicode_urls', rex_post('yrewrite_unicode_urls', 'bool'));
             $addon->setConfig('yrewrite_hide_url_block', rex_post('yrewrite_hide_url_block', 'bool'));
             $addon->setConfig('yrewrite_hide_seo_block', rex_post('yrewrite_hide_seo_block', 'bool'));
 
-            $message = rex_view::success($addon->i18n('yrewrite_seo_saved'));
+            rex_yrewrite::deleteCache();
+
+            $message = rex_view::success($addon->i18n('yrewrite_settings_saved'));
         }
 
         return $message;
@@ -45,6 +48,10 @@ class rex_yrewrite_seo_visibility
 
         // Checkboxes
         $checkbox_elements = [
+            [
+                'label' => '<label for="yrewrite-unicode-urls">'.$addon->i18n('yrewrite_unicode_urls').'</label>',
+                'field' => '<input type="checkbox" id="yrewrite-unicode-urls" name="yrewrite_unicode_urls" value="1" '.($addon->getConfig('unicode_urls') ? ' checked="checked"' : '').' />',
+            ],
             [
                 'label' => '<label for="yrewrite-hide-url-block">'.$addon->i18n('yrewrite_hide_url_block').'</label>',
                 'field' => '<input type="checkbox" id="yrewrite-hide-url-block" name="yrewrite_hide_url_block" value="1" '.($addon->getConfig('yrewrite_hide_url_block') ? ' checked="checked"' : '').' />',
@@ -72,7 +79,7 @@ class rex_yrewrite_seo_visibility
         // Form
         $fragment = new rex_fragment();
         $fragment->setVar('class', 'edit');
-        $fragment->setVar('title', $addon->i18n('yrewrite_seo_settings'));
+        $fragment->setVar('title', $addon->i18n('yrewrite_settings'));
         $fragment->setVar('body', $checkboxes, false);
         $fragment->setVar('buttons', $submit, false);
 
@@ -90,6 +97,9 @@ class rex_yrewrite_seo_visibility
     {
         $addon = self::getAddon();
 
+        if (!$addon->hasConfig('unicode_urls')) {
+            $addon->setConfig('unicode_urls', false);
+        }
         if (!$addon->hasConfig('yrewrite_hide_url_block')) {
             $addon->setConfig('yrewrite_hide_url_block', false);
         }

--- a/pages/setup.php
+++ b/pages/setup.php
@@ -35,12 +35,12 @@ $content = '
 
 
             <h3>' . $this->i18n('info_tipps') . '</h3>
-            <p>' . rex_i18n::rawMsg('yrewrite_info_tipps_text') . '    
-            
-            
+            <p>' . rex_i18n::rawMsg('yrewrite_info_tipps_text') . '
+
+
             <h3>' . $this->i18n('info_seo') . '</h3>
             <p>' . rex_i18n::rawMsg('yrewrite_info_seo_text') . '
-            
+
             <br /><br />'.highlight_string('<?php
 	  $seo = new rex_yrewrite_seo();
 	  echo $seo->getTitleTag().PHP_EOL;
@@ -60,8 +60,8 @@ echo $fragment->parse('core/page/section.php');
 /**
  * Process and display visibility settings form
  */
-echo rex_yrewrite_seo_visibility::processFormPost();
-echo rex_yrewrite_seo_visibility::getForm();
+echo rex_yrewrite_settings::processFormPost();
+echo rex_yrewrite_settings::getForm();
 
 $domains = [];
 


### PR DESCRIPTION
Mit diesem PR wird es in yrewrite eine globale Einstellung geben, ob Unicode-URLs verwendet werden sollen.
Default ist die vorerst nicht aktiviert, langfristig wollen wir das aber ändern.

Ich bin mir noch nicht 100% sicher, welche Zeichen genau in dem Modus dann trotzdem noch ersetzt werden sollen, und welche erhalten bleiben sollen.
Aktuell ist im PR das Verhalten so:

- Großbuchstaben werden zu Kleinbuchstaben (finde ich in URLs schöner)
- Apostrophe werden ersatzlos gelöscht (`don't` wird zu `dont` etc.)
- Ansonsten werden alle Zeichen durch "-" ersetzt, außer diese:
    - Unicode-Letters (also normale Schriftzeichen inkl. Umlaute, chinesische/kyrillische Zeichen etc.)
    - Zahlen
    - Währungszeichen ($, € etc.)
- Mehrfache "--" werden zu einem "-", und "-" am Anfang/Ende werden entfernt

Beispiele:

| Artikel | URL |
| --- | --- |
| Äußerst schön & günstig | `/äußerst-schön-günstig/` |
| Macht's gut | `/machts-gut/` |
| Wahnsinn, 💥 nur 3,80€ 👍 | `/wahnsinn-nur-3-80€/` |
| 今日は নমস্কার Привет Čau | `/今日は-নমস্কার-привет-čau/` |

Somit werden die ganzen Sonderzeichen/Punktuationszeichen (`/()[]%&,._"` etc.) weiterhin entfernt/ersetzt. Ich tendiere dazu, dass man die alle nicht in der URL haben möchte.

Auch entfernt werden aktuell Emojis. Wäre zwar irgendwie lustig, aber ich tendiere insgesamt trotzdem dazu, dass man sie eher nicht in der URL haben möchte. Aber da bin ich mir unsicher.

Bei der Apostroph-Sonderregel bin ich mir auch noch nicht 100% sicher, ob man die so möchte. Im Deutschen würde ich sagen ja. Im Englischen weiß ich nicht genau, was besser ist. 

Sprachspezifische Regeln möchte ich hier aktuell nicht einführen, sondern einen guten allgemeinen Default finden. Man kann es ja immer auch noch über die eigene Schemaklasse weiter spezifizieren.