### PR TITLE
Vorschaulinks unter setup extern öffnen

### DIFF
--- a/pages/setup.php
+++ b/pages/setup.php
@@ -67,7 +67,7 @@ $domains = [];
 
 foreach (rex_yrewrite::getDomains() as $name => $domain) {
     if ($name != 'default') {
-        $domains[] = '<tr><td><a href="'.$domain->getUrl().'">'.htmlspecialchars($name).'</a></td><td><a href="'.$domain->getUrl().'sitemap.xml">sitemap.xml</a></td><td><a href="'.$domain->getUrl().'robots.txt">robots.txt</a></td></tr>';
+        $domains[] = '<tr><td><a target="_blank" href="'.$domain->getUrl().'">'.htmlspecialchars($name).'</a></td><td><a target="_blank" href="'.$domain->getUrl().'sitemap.xml">sitemap.xml</a></td><td><a target="_blank" href="'.$domain->getUrl().'robots.txt">robots.txt</a></td></tr>';
     }
 }
 


### PR DESCRIPTION
Nur eine Kleinigkeit: die Links zur Sitemap, robots.txt und zur Domian sollten _blank öffnen ... man macht sich immer wieder aus Versehen Redaxo dicht. Und man möchte die Sitemap ja auch parallel checken, wenn man die einstellungen der Artikel anpasst.