### PR TITLE
Add chatops phpstan-baseline command

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,18 @@
+name: Chatops
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash-command-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.STAABM_TOKEN }}
+          # reactions should be reported from github itself
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: phpstan-baseline
+          issue-type: pull-request

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,27 +1,54 @@
 name: PHP Checks
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
+    repository_dispatch:
+        types: [phpstan-baseline-command] # triggered by /phpstan-baseline PR comment
 
 jobs:
 
-  phpstan-analysis:
-      name: phpstan static code analysis
-      runs-on: ubuntu-latest
+    phpstan-analysis:
+        name: phpstan static code analysis
+        runs-on: ubuntu-latest
 
-      steps:
-          - uses: actions/checkout@v2
-          - name: Setup PHP
-            uses: shivammathur/setup-php@v2
-            with:
-                php-version: 7.4
-                extensions: intl, imagick
-                coverage: none # disable xdebug, pcov
-                tools: cs2pr
+        steps:
+        - name: Add action run link to trigger comment
+          if: "github.event_name == 'repository_dispatch'"
+          uses: peter-evans/create-or-update-comment@v1
+          with:
+            token: ${{ secrets.STAABM_TOKEN }}
+            repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+            comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+            body: |
+              ```
+              https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              ```
+        - uses: actions/checkout@v2
+          with:
+            token: ${{ secrets.STAABM_TOKEN }}
+            repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
-          - name: Install Dependencies
-            run: composer install --prefer-dist
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+              php-version: 7.4
+              extensions: intl, imagick
+              coverage: none # disable xdebug, pcov
 
-          - run: |
-                vendor/bin/phpstan analyse --no-progress
+        - name: Install Dependencies
+          run: composer install --ansi --prefer-dist
+
+        - run: composer phpstan-baseline # generate baseline
+          if: "github.event_name == 'repository_dispatch'"
+        - name: Commit changed files
+          if: "github.event_name == 'repository_dispatch'"
+          uses: stefanzweifel/git-auto-commit-action@v4
+          with:
+            commit_message: Apply phpstan-baseline changes
+            branch: ${{ github.head_ref }}
+            file_pattern: '*.neon'
+
+        - run: vendor/bin/phpstan analyse --ansi --no-progress
+          if: "github.event_name != 'repository_dispatch'"


### PR DESCRIPTION
phpstan handling passiert nur noch in den Pull Requests, nicht mehr lokal. d.h. um eine baseline neu in einem pull-request zu generieren schreibt man im Pull Request den kommentar /phpstan-baseline. dadurch wird eine GitHub Action getriggert, die die baseline neu generiert (alle errors die im PR noch vorhanden sind, landen auf der ignore-list bzw. errors die ggf. nicht mehr vorhanden sind werden aus der baseline entfernt).