### PR TITLE
add missing mime type application/wasm to .wasm files

### DIFF
--- a/setup/.htaccess
+++ b/setup/.htaccess
@@ -24,6 +24,7 @@ AddDefaultCharset utf-8
 	AddType application/x-font-ttf .ttf
 	AddType application/font-woff .woff
 	AddType application/font-woff2 .woff2
+	AddType application/wasm .wasm
 	AddType font/opentype .otf
 </IfModule>
 


### PR DESCRIPTION
add missing mime type application/wasm to .wasm files

currently loaded will be rejected by the browser. error message in chrome console:

`Uncaught (in promise) TypeError: Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.`

this pull requests adds the type to the .htaccess file located in setup/.htaccess. I guess this file will be written to root, when someone clicks setup/htaccess-Datei setzen in the addon backend page