### PR TITLE
htaccess automatisch installieren, automatisch sichern

### DIFF
--- a/install.php
+++ b/install.php
@@ -81,3 +81,5 @@ if (!class_exists('rex_yrewrite_settings')) {
     require_once('lib/yrewrite/settings.php');
 }
 rex_yrewrite_settings::install();
+
+rex_yrewrite::copyHtaccess();

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -720,7 +720,7 @@ class rex_yrewrite
     {
         /* Backup current .htaccess in addon data folder */
         if (rex_file::get(rex_path::base('.htaccess'))) {
-            rex_file::copy(rex_file::get(rex_path::base('.htaccess'), rex_path::addonData('yrewrite', date("F j, Y, g:i").'.htaccess.bak')));
+            rex_file::copy(rex_file::get(rex_path::base('.htaccess')), rex_path::addonData('yrewrite', date("F j, Y, g:i").'.htaccess.bak'));
         }
         
         rex_file::copy(rex_path::addon('yrewrite', 'setup/.htaccess'), rex_path::frontend('.htaccess'));

--- a/update.php
+++ b/update.php
@@ -27,13 +27,13 @@ if (rex_string::versionCompare($this->getVersion(), '2.1', '<=')) {
 
     rex_sql_table::get(rex::getTable('yrewrite_domain'))
         ->removeColumn('alias_domain')
-		->ensureColumn(new rex_sql_column('auto_redirect', 'tinyint(1)'))
-		->ensureColumn(new rex_sql_column('auto_redirect_days', 'int(3)'))
+        ->ensureColumn(new rex_sql_column('auto_redirect', 'tinyint(1)'))
+        ->ensureColumn(new rex_sql_column('auto_redirect_days', 'int(3)'))
         ->alter();
 
     rex_sql_table::get(rex::getTable('yrewrite_forward'))
         ->removeColumn('domain')
- 	    ->ensureColumn(new rex_sql_column('expiry_date', 'date'))
+        ->ensureColumn(new rex_sql_column('expiry_date', 'date'))
         ->alter();
 
     rex_delete_cache();
@@ -53,3 +53,5 @@ if (rex_string::versionCompare($this->getVersion(), '2.7-dev', '<=')) {
 
     rex_yrewrite::deleteCache();
 }
+
+rex_yrewrite::copyHtaccess();

--- a/update.php
+++ b/update.php
@@ -54,4 +54,3 @@ if (rex_string::versionCompare($this->getVersion(), '2.7-dev', '<=')) {
     rex_yrewrite::deleteCache();
 }
 
-rex_yrewrite::copyHtaccess();


### PR DESCRIPTION
Änderung des Prozess, wie die htaccess und Aktualisierungen automatisch erfolgen (könnten) als Diskussionsgrundlage

+ automatisches Backup in den data-Ordner #312
+ htaccess wird bei install automatisch installiert
- muss bei nginx nicht automatisch installiert werden (überflüssig)
- installiert nginx-Profil nicht mit
- update.php würde eigene Anpassungen überschreiben. Betrifft #122

Man könnte bspw. den aktuellen Inhalt noch mit der mitgeführten htaccess vergleichen und nur updaten, wenn die Datei nicht verändert wurde.

Desweiteren könnte man auch die aktuelle .htaccess im Backend anzeigen lassen, falls relevant.