### PR TITLE
Redirect: Slash in URL korrigiert

### DIFF
--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -234,7 +234,7 @@ class rex_yrewrite_path_resolver
     private function redirect(string $host, string $url, string $params, string $status = rex_response::HTTP_MOVED_PERMANENTLY)
     {
         header('HTTP/1.1 '.$status);
-        header('Location: ' . $host . ltrim($url, '/') . $params);
+        header('Location: ' . $host . $url . $params);
         exit;
     }
 }

--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -234,7 +234,7 @@ class rex_yrewrite_path_resolver
     private function redirect(string $host, string $url, string $params, string $status = rex_response::HTTP_MOVED_PERMANENTLY)
     {
         header('HTTP/1.1 '.$status);
-        header('Location: ' . $host . $url . $params);
+        header('Location: ' . rtrim($host, '/') . '/' . ltrim($url, '/') . $params);
         exit;
     }
 }


### PR DESCRIPTION
Alter Code hat aus `$host` (//meinedomain.de) und `$url` (/de) eine falsche URL gebaut: //meinedomain.dede. Der Fehler trat z.B. bei der Wahl der automatischen Startsprache auf. Wohlgemerkt ist in `$host` kein trailing slash vorhanden.
Die Codeänderung belässt das leading slash in der URL.