### PR TITLE
TypeError bei leerem Host abfangen

### DIFF
--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -41,7 +41,9 @@ class rex_yrewrite_path_resolver
         [$url, $params] = $this->normalizeAndSplitUrl($url);
 
         $host = rex_yrewrite::getHost();
-
+        if (is_null($host)){
+            return;
+        }
         $domain = $this->resolveDomain($host, $url, $params);
 
         $currentScheme = rex_yrewrite::isHttps() ? 'https' : 'http';


### PR DESCRIPTION
Wenn der Client keinen $host zurück liefert, taucht ein TypeError im syslog auf

Error: TypeError
Nachricht: Argument 1 passed to rex_yrewrite_path_resolver::resolveDomain() must be of the type string, null given, called in /var/www/html/factfinder/tld/de/htdocs/redaxo/src/addons/yrewrite/lib/yrewrite/path_resolver.php on line 45
Datei: redaxo/src/addons/yrewrite/lib/yrewrite/path_resolver.php
Zeile: 158