### PR TITLE
YRewrite Domains - auch Zugriff für andere Rollen ermöglichen

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -9,7 +9,7 @@ page:
     perm: yrewrite[forward]
     pjax: true
     subpages:
-        domains: { title: 'translate:domains', perm: admin }
+        domains: { title: 'translate:domains', perm: 'yrewrite[domain]' }
         alias_domains: { title: 'translate:alias_domains', perm: admin }
         forward: { title: 'translate:forward', perm: 'yrewrite[forward]' }
         setup: { title: 'translate:setup', perm: admin }


### PR DESCRIPTION
Use Case; Kunde, der eigenständig Landing Pages auf unterschiedlichen Domains aufbaut und dieser daher Zugriff auf den Bereich Domains benötigt.