### PR TITLE
fix warning for non-existant path entry for a certain language

### DIFF
--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -212,7 +212,7 @@ class rex_yrewrite_seo
 
             foreach (rex_yrewrite::getPathsByDomain($domain->getName()) as $article_id => $path) {
                 foreach ($domain->getClangs() as $clang_id) {
-                    if (!rex_clang::get($clang_id)->isOnline()) {
+                    if (!rex_clang::get($clang_id)->isOnline() || !isset($path[$clang_id])) {
                         continue;
                     }
 


### PR DESCRIPTION
closes #462

Wenn z.B. für die Sprache "1" ein Artikel umgeleitet ist, erscheint er in der pathlist Datei "hinten" unter "redirections" und "vorne" in "path" fehlt der Eintrag. 
Also ist in https://github.com/yakamara/redaxo_yrewrite/blob/main/lib/yrewrite/seo.php#L250
 `$path[$clang_id]` nicht definiert... -> ergo die Warning.