### PR TITLE
Fix path_resolver for console context

### DIFF
--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -42,7 +42,11 @@ class rex_yrewrite_path_resolver
 
         $host = rex_yrewrite::getHost();
 
-        $domain = $this->resolveDomain($host, $url, $params);
+        if (is_null($host)) {
+            $domain = $this->domainsByName['default'];
+        } else {
+            $domain = $this->resolveDomain($host, $url, $params);
+        }
 
         $currentScheme = rex_yrewrite::isHttps() ? 'https' : 'http';
         $domainScheme = $domain->getScheme();


### PR DESCRIPTION
`$host` is NULL if `resolve(...)` is invoke via a console command. This will cause a crash when calling `$this->resolveDomain(...)`. This causes a crash in several console commands e.g. `install:list` and `user:create`.