### PR TITLE
Standardeffekt Skalieren hinzugefügt

### DIFF
--- a/install.php
+++ b/install.php
@@ -84,7 +84,7 @@ if (0 == $c->getRows()) {
     $c->setQuery('INSERT INTO '. rex::getTable('media_manager_type') ." (`status`, `name`, `description`) VALUES
         (0, 'yrewrite_seo_image', 'YRewrite SEO Vorschaubild für Sitemap und Open Graph Tags');");
     $last_id = $c->getLastId();
-    $c->setQuery("INSERT INTO ". \rex::getTablePrefix() ."media_manager_type_effect (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
+    $c->setQuery('INSERT INTO '.\rex::getTable('media_manager_type_effect').' (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
 		(". $last_id .", 'resize', '{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}', 1, CURRENT_TIMESTAMP);");
 }
 

--- a/install.php
+++ b/install.php
@@ -83,6 +83,9 @@ $c->setQuery('SELECT * FROM '. rex::getTable('media_manager_type') ." WHERE name
 if (0 == $c->getRows()) {
     $c->setQuery('INSERT INTO '. rex::getTable('media_manager_type') ." (`status`, `name`, `description`) VALUES
         (0, 'yrewrite_seo_image', 'YRewrite SEO Vorschaubild für Sitemap und Open Graph Tags');");
+    $last_id = $c->getLastId();
+    $c->setQuery("INSERT INTO ". \rex::getTablePrefix() ."media_manager_type_effect (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
+		(". $last_id .", 'resize', '{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}', 1, CURRENT_TIMESTAMP);");
 }
 
 rex_delete_cache();

--- a/install.php
+++ b/install.php
@@ -85,8 +85,7 @@ if (0 == $c->getRows()) {
         (0, 'yrewrite_seo_image', 'YRewrite SEO Vorschaubild für Sitemap und Open Graph Tags');");
     $last_id = $c->getLastId();
     $c->setQuery('INSERT INTO '.\rex::getTable('media_manager_type_effect').' (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
-		('.$last_id .', 'resize', '{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}', 1, CURRENT_TIMESTAMP);');
-}
+		('.$last_id .', \'resize\', \'{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}\', 1, CURRENT_TIMESTAMP);');}
 
 rex_delete_cache();
 

--- a/install.php
+++ b/install.php
@@ -85,7 +85,7 @@ if (0 == $c->getRows()) {
         (0, 'yrewrite_seo_image', 'YRewrite SEO Vorschaubild für Sitemap und Open Graph Tags');");
     $last_id = $c->getLastId();
     $c->setQuery('INSERT INTO '.\rex::getTable('media_manager_type_effect').' (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
-		(". $last_id .", 'resize', '{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}', 1, CURRENT_TIMESTAMP);");
+		('.$last_id .', 'resize', '{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}', 1, CURRENT_TIMESTAMP);');
 }
 
 rex_delete_cache();

--- a/install.php
+++ b/install.php
@@ -85,7 +85,8 @@ if (0 == $c->getRows()) {
         (0, 'yrewrite_seo_image', 'YRewrite SEO Vorschaubild für Sitemap und Open Graph Tags');");
     $last_id = $c->getLastId();
     $c->setQuery('INSERT INTO '.\rex::getTable('media_manager_type_effect').' (`type_id`, `effect`, `parameters`, `priority`, `createdate`) VALUES
-		('.$last_id .', \'resize\', \'{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}\', 1, CURRENT_TIMESTAMP);');}
+        ('.$last_id .', \'resize\', \'{\"rex_effect_resize\":{\"rex_effect_resize_width\":\"4096\",\"rex_effect_resize_height\":\"4096\",\"rex_effect_resize_style\":\"maximum\",\"rex_effect_resize_allow_enlarge\":\"not_enlarge\"}}\', 1, CURRENT_TIMESTAMP);');
+}
 
 rex_delete_cache();
 

--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -94,9 +94,9 @@ class rex_yrewrite_seo
                 }
                 $tagsOg['og:image:type'] = '<meta property="og:image:type" content="'.rex_escape($media->getType()).'" />';
             }
-            $tagsOg['twitter:image'] = '<meta property="twitter:image" content="'.rtrim($this->domain->getUrl(), '/').rex_media_manager::getUrl('yrewrite_seo_image', $image).'" />';
+            $tagsOg['twitter:image'] = '<meta name="twitter:image" content="'.rtrim($this->domain->getUrl(), '/').rex_media_manager::getUrl('yrewrite_seo_image', $image).'" />';
             if ($media && $media->getTitle()) {
-                $tagsOg['twitter:image:alt'] = '<meta property="twitter:image:alt" content="'.rex_escape($media->getTitle()).'" />';
+                $tagsOg['twitter:image:alt'] = '<meta name="twitter:image:alt" content="'.rex_escape($media->getTitle()).'" />';
             }
         }
 


### PR DESCRIPTION
2 Änderungen:

- Standardeffekt skaliert das Bild auf die maximale Seitenlänge 4096x4096px um der maximalen Twitter Bildgröße zu entsprechen
- Twitter Tags werden nicht über das Attribut "property" sondern "name" ausgegeben.