### PR TITLE
Weiterleitungen: Spalte zur Anzeige der Weiterleitungsziele

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -176,6 +176,10 @@ yrewrite_forward_302 = 302 - Found / gefunden
 yrewrite_forward_303 = 303 - See Other / normale Weiterleitung
 yrewrite_forward_307 = 307 - Temporary Redirect / vorübergehende Weiterleitung
 
+yrewrite_forward_article_deleted = [Artikel gelöscht]
+yrewrite_forward_article_offline = [Artikel offline]
+yrewrite_forward_media_deleted = [Medium gelöscht]
+
 yrewrite_auto_redirect = Automatische 301-Weiterleitungen setzen, wenn ein Artikel umbenannt oder verschoben wird. (Sollte bei der Entwicklung ausgeschaltet sein und erst im Livebetrieb eingeschaltet werden.)
 yrewrite_auto_redirect_days = Anzahl Tage, bis automatische Weiterleitungen inaktiv werden.
 yrewrite_auto_redirect_days_info = <code>0</code> eintragen, um die automatische Deaktivierung auszuschalten.

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -175,6 +175,10 @@ yrewrite_forward_302 = 302 - Found / Gefunden
 yrewrite_forward_303 = 303 - See Other / default redirect
 yrewrite_forward_307 = 307 - Temporary Redirect
 
+yrewrite_forward_article_deleted = [Article deleted]
+yrewrite_forward_article_offline = [Article deleted]
+yrewrite_forward_media_deleted = [Media deleted]
+
 yrewrite_auto_redirect = Send automatic 301 redirects when articles are renamed or moved. (Should be disabled during development and only enabled in live environments)
 yrewrite_auto_redirect_days = Number of days until automatic redirects are deactivated.
 yrewrite_auto_redirect_days_info = Enter 0 to disable automatic deactivation

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -176,7 +176,7 @@ yrewrite_forward_303 = 303 - See Other / default redirect
 yrewrite_forward_307 = 307 - Temporary Redirect
 
 yrewrite_forward_article_deleted = [Article deleted]
-yrewrite_forward_article_offline = [Article deleted]
+yrewrite_forward_article_offline = [Article offline]
 yrewrite_forward_media_deleted = [Media deleted]
 
 yrewrite_auto_redirect = Send automatic 301 redirects when articles are renamed or moved. (Should be disabled during development and only enabled in live environments)

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -169,7 +169,7 @@ if ($showlist) {
     $list->setColumnLabel('status', $this->i18n('forward_status'));
     // $list->setColumnLabel('url', $this->i18n('forward_url'));
     $list->removeColumn('url');
-    $list->setColumnLabel('type', $this->i18n('forward_type'));
+    $list->removeColumn('type');
 
     $list->setColumnLabel('movetype', $this->i18n('yrewrite_forward_movetype'));
 

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -196,7 +196,6 @@ if ($showlist) {
     );
 
     $list->addColumn('forward_target', '', 3);
-    $list->setColumnSortable('forward_target');
     $list->setColumnLabel('forward_target', $this->i18n('forward_type'));
     $list->setColumnFormat('forward_target', 'custom', static function (array $params) {
         $list = $params['list'];

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -195,7 +195,8 @@ if ($showlist) {
     }
     );
 
-    $list->addColumn('forward_target', '');
+    $list->addColumn('forward_target', '', 3);
+    $list->setColumnSortable('forward_target');
     $list->setColumnLabel('forward_target', $this->i18n('forward_type'));
     $list->setColumnFormat('forward_target', 'custom', static function (array $params) {
         $list = $params['list'];

--- a/pages/forward.php
+++ b/pages/forward.php
@@ -195,6 +195,42 @@ if ($showlist) {
     }
     );
 
+    $list->addColumn('forward_target', '');
+    $list->setColumnLabel('forward_target', $this->i18n('forward_type'));
+    $list->setColumnFormat('forward_target', 'custom', static function (array $params) {
+        $list = $params['list'];
+
+        switch ($list->getValue('type')) {
+            case 'article':
+                $article = rex_article::get($list->getValue('article_id'), $list->getValue('clang'));
+                if (!$article) {
+                    return rex_i18n::msg('yrewrite_forward_article_deleted');
+                }
+                if (!$article->isOnline()) {
+                    return rex_i18n::msg('yrewrite_forward_article_offline');
+                }
+
+                return $article->getUrl();
+                break;
+
+            case 'extern':
+                return $list->getValue('extern');
+                break;
+
+            case 'media':
+                $media = rex_media::get($list->getValue('media'));
+                if (!$media) {
+                    return rex_i18n::msg('yrewrite_forward_media_deleted');
+                }
+
+                return $media->getUrl();
+                break;
+
+            default:
+                return $params['value'];
+        }
+    });
+
     $list->addColumn(rex_i18n::msg('function'), '<i class="rex-icon rex-icon-edit"></i> ' . rex_i18n::msg('edit'));
     $list->setColumnLayout(rex_i18n::msg('function'), ['<th class="rex-table-action" colspan="2">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
     $list->setColumnParams(rex_i18n::msg('function'), ['data_id' => '###id###', 'func' => 'edit', 'start' => rex_request('start', 'string')]);


### PR DESCRIPTION
Damit werden die Weiterleitungsziele in der Übersichtsliste angezeigt. 
Das hilft z.B. dabei, gelöschte Artikel oder Medien zu identifizieren.