### PR TITLE
Umleitungsschleife beheben

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -219,10 +219,13 @@ class rex_yrewrite
     {
         if (rex::isFrontend() && 'get' === rex_request_method() && !rex_get('rex-api-call') && $articleId = rex_get('article_id', 'int')) {
             $params = $_GET;
-            unset($params['article_id']);
-            unset($params['clang']);
-            $url = self::getFullUrlByArticleId($articleId, null, $params, '&');
-            rex_response::sendRedirect($url, rex_response::HTTP_MOVED_PERMANENTLY);
+            $article = rex_article::get($params['article_id'], $params['clang']);
+            if($article instanceof rex_article) {
+		        unset($params['article_id']);
+		        unset($params['clang']);
+		        $url = self::getFullUrlByArticleId($articleId, null, $params, '&');
+		        rex_response::sendRedirect($url, rex_response::HTTP_MOVED_PERMANENTLY);
+	        }
         }
 
         if ($articleId = rex_request('article_id', 'int')) {

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -220,12 +220,12 @@ class rex_yrewrite
         if (rex::isFrontend() && 'get' === rex_request_method() && !rex_get('rex-api-call') && $articleId = rex_get('article_id', 'int')) {
             $params = $_GET;
             $article = rex_article::get($params['article_id'], $params['clang']);
-            if($article instanceof rex_article) {
-		        unset($params['article_id']);
-		        unset($params['clang']);
-		        $url = self::getFullUrlByArticleId($articleId, null, $params, '&');
-		        rex_response::sendRedirect($url, rex_response::HTTP_MOVED_PERMANENTLY);
-	        }
+            if ($article instanceof rex_article) {
+                unset($params['article_id']);
+                unset($params['clang']);
+                $url = self::getFullUrlByArticleId($articleId, null, $params, '&');
+                rex_response::sendRedirect($url, rex_response::HTTP_MOVED_PERMANENTLY);
+            }
         }
 
         if ($articleId = rex_request('article_id', 'int')) {


### PR DESCRIPTION
Prüft, ob ein Artikel existiert, bevor auf ihn umgeleitet wird. Fix https://github.com/yakamara/redaxo_yrewrite/issues/498