### PR TITLE
hreflangs: x-default bei Auto-Sprachweiterleitung

### DIFF
--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -71,6 +71,12 @@ class rex_yrewrite_path_resolver
         if ('' === $url && $domain->isStartClangAuto()) {
             $startClang = $this->resolveAutoStartClang($domain);
 
+            $hreflangs = [];
+            foreach ((new rex_yrewrite_seo())->getHrefLangs() as $lang => $href) {
+                $hreflangs[] = "<$href>;  rel=\"alternate\"; hreflang=\"$lang\"";
+            }
+            header('Link: '.implode(', ', $hreflangs));
+
             $this->redirect($currentScheme . '://' . $host, rex_getUrl($domain->getStartId(), $startClang), $params, '302 Found');
         }
 

--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -202,8 +202,12 @@ class rex_yrewrite_seo
     public function getHrefLangs()
     {
         $current_mount_id = $this->domain->getMountId();
-
         $lang_domains = [];
+
+        if ($this->domain->isStartClangAuto() && $this->domain->getStartId() === rex_article::getCurrentId()) {
+            $lang_domains['x-default'] = $this->domain->getUrl();
+        }
+
         foreach (rex_yrewrite::getDomains() as $domain) {
             if ($current_mount_id == $domain->getMountId()) {
                 foreach ($domain->getClangs() as $clang) {


### PR DESCRIPTION
closes #511

In dem Issue war aufgefallen, dass wir bei der automatischen Startseiten-Sprachweiterleitung (gemäß Browsersprache) noch nicht `x-default` als hreflang setzen.
https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages?hl=de

Neu liefert nun `rex_yrewrite_seo::getHrefLangs` auch den Wert für `x-default`, wenn man sich auf der Startseite befindet und für die Domain die automatische Sprachweiterleitung eingerichtet wurde.
Auf den einzelnen Sprach-Startseiten ist man weiterhin selbst verantwortlich, die Hreflang-Tags auch auszugeben (z.b. per `$seo->getTags()`). Dort ist dann `x-default` auch enthalten.

Während der Weiterleitung hingegen setzt yrewrite selbst die hreflangs (dort per Link-Header statt Meta-Tags, da wir gar keinen Antwort-Body für die Weiterleitung generieren).