### PR TITLE
Weiterleitung mit mehr Params bevorzugt wählen

### DIFF
--- a/lib/yrewrite/forward.php
+++ b/lib/yrewrite/forward.php
@@ -42,6 +42,8 @@ class rex_yrewrite_forward
         $domain = $params['domain'];
         $url = mb_strtolower($params['url']);
 
+        $forward_url = '';
+        $matchingParams = -1;
         foreach (self::$paths as $p) {
             $forwardDomain = rex_yrewrite::getDomainById($p['domain_id']);
 
@@ -55,13 +57,16 @@ class rex_yrewrite_forward
                 continue;
             }
 
+            if (count($p['params'] ?? []) <= $matchingParams) {
+                continue;
+            }
+
             foreach ($p['params'] ?? [] as $key => $value) {
                 if (rex_get($key) !== $value) {
                     continue 2;
                 }
             }
 
-            $forward_url = '';
             if ('article' == $p['type'] && ($art = rex_article::get($p['article_id'], $p['clang']))) {
                 $forward_url = rex_getUrl($p['article_id'], $p['clang']);
             } elseif ('media' == $p['type'] && ($media = rex_media::get($p['media']))) {
@@ -71,11 +76,16 @@ class rex_yrewrite_forward
             }
 
             if ('' != $forward_url) {
-                header('HTTP/1.1 '.self::$movetypes[$p['movetype']]);
-                header('Location: ' . $forward_url);
-                exit;
+                $matchingParams = count($p['params'] ?? []);
             }
         }
+
+        if ('' != $forward_url) {
+            header('HTTP/1.1 '.self::$movetypes[$p['movetype']]);
+            header('Location: ' . $forward_url);
+            exit;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
fixes #509

Wenn mehrere Weiterleitungen matchen, wird nun die gewählt, die mehr Params enthält.
@michael-kreatif und @alxndr-w Macht das für euch so Sinn?

Angenommen es wurden diese Weiterleitungen eingerichtet:
1. `/abc`
2. `/abc?foo`
3. `/abc?bar&baz`

Dann gilt:
Aufgerufen | verwendete<br>Weiterleitung | Begründung
--- | --- | ---
`/abc` | 1 | Einziges Matching
`/abc?def` | 1 | Einziges Matching
`/abc?foo&bar` | 2 | Matcht auf 1 und 2 (auf 3 nicht, weil `baz` fehlt), 2 hat aber mehr Params als 1
`/abc?bar&baz&def` | 3 | Matcht auf 1 und 3, aber 3 hat mehr Params
`/abc?foo&bar&baz` | 3 | Alle drei matchen, aber 3 hat die meisten Params