### PR TITLE
sitemap für einzelne Sprachen und / oder Domains

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -156,8 +156,11 @@ rex_extension::register('PACKAGES_INCLUDED', function ($params) {
 
 if ('sitemap' == rex_request('rex_yrewrite_func', 'string')) {
     rex_extension::register('PACKAGES_INCLUDED', static function ($params) {
+        $domain = rex_request('rex_yrewrite_param_domain', 'string', '');
+        $lang = rex_request('rex_yrewrite_param_clang', 'integer', 0);
+
         $sitemap = new rex_yrewrite_seo();
-        $sitemap->sendSitemap();
+        $sitemap->sendSitemap($domain, $lang);
     }, rex_extension::LATE);
 }
 

--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -248,7 +248,7 @@ class rex_yrewrite_seo
         exit;
     }
 
-    public function sendSitemap($domain = '')
+    public function sendSitemap($domain = '', $clang = 0)
     {
         $domains = rex_yrewrite::getDomains();
 
@@ -273,7 +273,7 @@ class rex_yrewrite_seo
 
             foreach (rex_yrewrite::getPathsByDomain($domain->getName()) as $article_id => $path) {
                 foreach ($domain->getClangs() as $clang_id) {
-                    if (!isset($path[$clang_id]) || !rex_clang::get($clang_id)->isOnline()) {
+                    if (!isset($path[$clang_id]) || !rex_clang::get($clang_id)->isOnline() || ($clang > 0 && $clang != $clang_id)) {
                         continue;
                     }
 
@@ -325,7 +325,7 @@ class rex_yrewrite_seo
                     }
                 }
             }
-            $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_DOMAIN_SITEMAP', $sitemap, ['domain' => $domain]));
+            $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_DOMAIN_SITEMAP', $sitemap, ['domain' => $domain, 'clang' => $clang]));
         }
         $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_SITEMAP', $sitemap));
 


### PR DESCRIPTION
closes #547

mit diesem PR kann man in der .htaccess solche Zeilen setzen:
```
RewriteRule ^sitemap-de\.xml$ %{ENV:BASE}/index.php?rex_yrewrite_func=sitemap&rex_yrewrite_param_clang=1 [NC,L]
RewriteRule ^sitemap-en\.xml$ %{ENV:BASE}/index.php?rex_yrewrite_func=sitemap&rex_yrewrite_param_clang=2 [NC,L]
```

und dann per `https://mydomain.org/sitemap-en.xml` die englische sitemap bekommen.


Das mit dem domain Parameter habe ich nur der Vollständigkeit halber gemacht, weil es den Parameter in der sendSitemap() Funktion schon gab. Yrewrite gibt ja per default nur die zur domain "mydomain.org" gehörenden Links aus.
