### PR TITLE
Fix htaccess setup

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -115,6 +115,7 @@ yrewrite_index_noindex_follow = Indexierung verbieten und Links folgen / nicht i
 
 yrewrite_htaccess_hasbeenset = .htaccess-Datei wurde gesetzt/ersetzt
 yrewrite_htaccess_set = .htaccess-Datei setzen
+yrewrite_htaccess_hasnotbeenset = .htaccess-Datei konnte nicht gesetzt/ersetzt werden - Überprüfe die Schreibrechte
 
 yrewrite_htaccess_info = Um YRewrite in Betrieb zu nehmen, wird eine .htaccess-Datei im Root-Ordner erstellt. Ist eine andere .htaccess-Datei bereits vorhanden, wird diese ersetzt. Bitte ggf. die .htaccess-Datei vorher sichern.
 

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -554,7 +554,7 @@ class rex_yrewrite
 
     public static function copyHtaccess()
     {
-        rex_file::copy(rex_path::addon('yrewrite', 'setup/.htaccess'), rex_path::frontend('.htaccess'));
+        return (rex_file::copy(rex_path::addon('yrewrite', 'setup/.htaccess'), rex_path::frontend('.htaccess')));
     }
 
     public static function isHttps()

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -554,7 +554,7 @@ class rex_yrewrite
 
     public static function copyHtaccess()
     {
-        return (rex_file::copy(rex_path::addon('yrewrite', 'setup/.htaccess'), rex_path::frontend('.htaccess')));
+        return rex_file::copy(rex_path::addon('yrewrite', 'setup/.htaccess'), rex_path::frontend('.htaccess'));
     }
 
     public static function isHttps()

--- a/pages/setup.php
+++ b/pages/setup.php
@@ -19,8 +19,11 @@ if ('' != $func) {
         echo rex_view::error(rex_i18n::msg('csrf_token_invalid'));
     } else {
         if ('htaccess' == $func) {
-            rex_yrewrite::copyHtaccess();
-            echo rex_view::success($this->i18n('htaccess_hasbeenset'));
+            if (rex_yrewrite::copyHtaccess()) {
+                echo rex_view::success($this->i18n('htaccess_hasbeenset'));
+            } else {
+                echo rex_view::error($this->i18n('htaccess_hasnotbeenset'));
+            }
         }
     }
 }


### PR DESCRIPTION
Ausgabe einer Fehlermeldung, wenn .htaccess nicht geschrieben werden konnte

Konnte die Datei nicht geschrieben werden, gab es bisher keinen Hinweis darauf. Der bisherige Code ging immer davon aus, dass das Schreiben der Datei immer erfolgreich verläuft.

Es fehlen noch die Anpassungen der anderen Sprachdateien.