### PR TITLE
Neue Extensionpoints für SEO-Informationen

### DIFF
--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -329,9 +329,7 @@ class rex_yrewrite_seo
             }
             $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_DOMAIN_SITEMAP', $sitemap, ['domain' => $domain]));
         }
-        $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_SITEMAP', $sitemap, [
-            'article' => $this->article
-        ]));
+        $sitemap = rex_extension::registerPoint(new rex_extension_point('YREWRITE_SITEMAP', $sitemap));
 
         rex_response::cleanOutputBuffers();
         header('Content-Type: application/xml');


### PR DESCRIPTION
Diese 2 Extension Points werden benötigt, um eine Standardausgabe von Seo-Description und Seo-Image zu ermöglichen, falls der Redakteur diese vergisst bzw. nicht bereitstellt. In unserem Fall holen wir die Texte sowie Bilder aus den Modulen des Artikels.