### PR TITLE
Added field to setup for excluding article_ids from rewriting

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -195,3 +195,4 @@ yrewrite_settings_saved = Einstellungen gespeichert
 yrewrite_unicode_urls = Unicode-Zeichen in URLs erlauben (Umlaute, chinesische/kyrillische Zeichen etc.)
 yrewrite_hide_url_block = URL-Block verbergen
 yrewrite_hide_seo_block = SEO-Block verbergen
+yrewrite_allow_article_ids = Aufruf von article_id erlauben (Bsp. 1,2,3)

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -194,3 +194,4 @@ yrewrite_settings_saved = Settings updated
 yrewrite_unicode_urls = Allow unicode chars in URLs (umlauts, chinese/cyrillic characters etc.)
 yrewrite_hide_url_block = Hide URL-Block
 yrewrite_hide_seo_block = Hide SEO-Block
+yrewrite_allow_article_ids = Allow article_id parameter (1,2,3)

--- a/lib/yrewrite/settings.php
+++ b/lib/yrewrite/settings.php
@@ -30,6 +30,7 @@ class rex_yrewrite_settings
             $addon->setConfig('unicode_urls', rex_post('yrewrite_unicode_urls', 'bool'));
             $addon->setConfig('yrewrite_hide_url_block', rex_post('yrewrite_hide_url_block', 'bool'));
             $addon->setConfig('yrewrite_hide_seo_block', rex_post('yrewrite_hide_seo_block', 'bool'));
+            $addon->setConfig('yrewrite_allow_article_ids', rex_post('yrewrite_allow_article_ids', 'string'));
 
             rex_yrewrite::deleteCache();
 
@@ -45,6 +46,8 @@ class rex_yrewrite_settings
     public static function getForm()
     {
         $addon = self::getAddon();
+
+        $formElements = [];
 
         // Checkboxes
         $checkbox_elements = [
@@ -64,7 +67,27 @@ class rex_yrewrite_settings
 
         $fragment = new rex_fragment();
         $fragment->setVar('elements', $checkbox_elements, false);
-        $checkboxes = $fragment->parse('core/form/checkbox.php');
+        $content = $fragment->parse('core/form/checkbox.php');
+
+        // Input Fields
+        $inputGroups = [];
+        $n = [];
+        $n['field'] = '<input class="form-control" type="text" id="yrewrite_allow_article_ids" name="yrewrite_allow_article_ids" value="' . $addon->getConfig('yrewrite_allow_article_ids') . '" />';
+        $n['left'] = $addon->i18n('yrewrite_allow_article_ids');
+        $inputGroups[] = $n;
+
+        $fragment = new rex_fragment();
+        $fragment->setVar('elements', $inputGroups, false);
+        $inputGroup = $fragment->parse('core/form/input_group.php');
+
+        $n = [];
+        $n['label'] = '';
+        $n['field'] = $inputGroup;
+        $formElements[] = $n;
+
+        $fragment = new rex_fragment();
+        $fragment->setVar('elements', $formElements, false);
+        $content .= $fragment->parse('core/form/form.php');
 
         // Submit
         $submit_elements = [
@@ -80,7 +103,7 @@ class rex_yrewrite_settings
         $fragment = new rex_fragment();
         $fragment->setVar('class', 'edit');
         $fragment->setVar('title', $addon->i18n('yrewrite_settings'));
-        $fragment->setVar('body', $checkboxes, false);
+        $fragment->setVar('body', $content, false);
         $fragment->setVar('buttons', $submit, false);
 
         return '
@@ -105,6 +128,9 @@ class rex_yrewrite_settings
         }
         if (!$addon->hasConfig('yrewrite_hide_url_block')) {
             $addon->setConfig('yrewrite_hide_url_block', false);
+        }
+        if (!$addon->hasConfig('yrewrite_allow_article_ids')) {
+            $addon->setConfig('yrewrite_allow_article_ids', '');
         }
     }
 }

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -217,7 +217,12 @@ class rex_yrewrite
 
     public static function prepare()
     {
-        if (rex::isFrontend() && 'get' === rex_request_method() && !rex_get('rex-api-call') && $articleId = rex_get('article_id', 'int')) {
+        if (rex::isFrontend() && 'get' === rex_request_method() && !rex_get('rex-api-call') && $articleId = rex_get('article_id', 'int'))
+        {
+            if (self::allowArticleId($articleId)) {
+                return true;
+            }
+
             $params = $_GET;
             $article = rex_article::get((int) $params['article_id'], (int) $params['clang']);
             if ($article instanceof rex_article) {
@@ -597,5 +602,16 @@ class rex_yrewrite
         }
 
         return rtrim($path, DIRECTORY_SEPARATOR) . '/';
+    }
+
+    protected static function allowArticleId($articleId)
+    {
+        $ids = explode(',', rex_addon::get('yrewrite')->getConfig('yrewrite_allow_article_ids'));
+
+        if (in_array($articleId, $ids)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
I had a problem to use a custom RewriteRule in htaccess which redirects to an url with the article_id parameter. Now such ids can be excluded from the rewriting process in the frontend.