### PR TITLE
Fixed deprecation warning

### DIFF
--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -220,7 +220,7 @@ class rex_yrewrite_seo
 
     public function cleanString($str)
     {
-        return str_replace(["\n", "\r"], [' ', ''], $str);
+        return str_replace(["\n", "\r"], [' ', ''], ($str ?? ''));
     }
 
     // ----- global static functions

--- a/lib/yrewrite/seo.php
+++ b/lib/yrewrite/seo.php
@@ -220,7 +220,7 @@ class rex_yrewrite_seo
 
     public function cleanString($str)
     {
-        return str_replace(["\n", "\r"], [' ', ''], ($str ?? ''));
+        return str_replace(["\n", "\r"], [' ', ''], $str ?? '');
     }
 
     // ----- global static functions


### PR DESCRIPTION
**Message:** `str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`

Tritt immer dann auf, wenn Redakteure irgendwo die SEO-Angaben nicht gesetzt haben.