### PR TITLE
Fix help redirect for subdirectory installations (#550)

### DIFF
--- a/help.php
+++ b/help.php
@@ -1,3 +1,3 @@
 <?php
 
-rex_response::sendRedirect(rex_url::backendController(['page'=>'yrewrite/docs']));
+rex_response::sendRedirect(rex_url::backendController(['page' => 'yrewrite/docs']));

--- a/help.php
+++ b/help.php
@@ -1,3 +1,3 @@
 <?php
 
-rex_response::sendRedirect('/redaxo/index.php?page=yrewrite/docs');
+rex_response::sendRedirect(rex_url::backendController(['page'=>'yrewrite/docs']));


### PR DESCRIPTION
Use rex_url::backendController() instead of hardcoded path to ensure help is accessible when REDAXO is installed in a subdirectory.