### PR TITLE
Fix getDomainByName() to handle domain variations (#556)

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -107,9 +107,25 @@ class rex_yrewrite
      */
     public static function getDomainByName($name)
     {
+        // Try exact match first (for backward compatibility)
         if (isset(self::$domainsByName[$name])) {
             return self::$domainsByName[$name];
         }
+
+        // Normalize search string: remove protocol and trailing slash
+        $normalizedName = preg_replace('#^https?://#', '', $name);
+        $normalizedName = rtrim($normalizedName, '/');
+
+        // Search through all domains with normalized comparison
+        foreach (self::$domainsByName as $storedName => $domain) {
+            $normalizedStoredName = preg_replace('#^https?://#', '', $storedName);
+            $normalizedStoredName = rtrim($normalizedStoredName, '/');
+
+            if ($normalizedName === $normalizedStoredName) {
+                return $domain;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
getDomainByName() now correctly finds domains regardless of whether they were stored with protocol (http://, https://) or trailing slashes.

The function first tries an exact match for backward compatibility, then falls back to normalized comparison by removing protocols and trailing slashes from both the search string and stored domain names.

This fixes issue #556 where domains stored as "https://domain.de/" or "domain.de/" could not be found when searching for "domain.de".