### PR TITLE
Pfad-Cache auch bei Struktur-Änderungen außerhalb des Backends regenerieren (REDAXO 6)

### DIFF
--- a/src/YRewriteAddon.php
+++ b/src/YRewriteAddon.php
@@ -53,23 +53,28 @@ class YRewriteAddon extends Addon
             }
 
             // if anything changes -> refresh PathFile
-            if (Core::isBackend()) {
-                $extensionPoints = [
-                    'CAT_ADDED', 'CAT_UPDATED', 'CAT_DELETED', 'CAT_STATUS', 'CAT_MOVED',
-                    'ART_ADDED', 'ART_UPDATED', 'ART_DELETED', 'ART_STATUS', 'ART_MOVED', 'ART_COPIED',
-                    'ART_META_UPDATED', 'ART_TO_STARTARTICLE', 'ART_TO_CAT', 'CAT_TO_ART',
-                    'CLANG_UPDATED',
-                ];
-                foreach ($extensionPoints as $extensionPoint) {
-                    Extension::register($extensionPoint, static function (ExtensionPoint $ep): void {
-                        $params = $ep->getParams();
-                        $params['subject'] = $ep->subject;
-                        $params['extension_point'] = $ep->name;
-                        YRewrite::generatePathFile($params);
-                    });
-                }
+            // Registered in every context, not only in the backend: structure changes can
+            // also be triggered headless (e.g. the api addon, console commands or cronjobs),
+            // and the path cache has to be refreshed there too. These extension points only
+            // fire when content actually changes, so there is no overhead on regular frontend
+            // requests.
+            $extensionPoints = [
+                'CAT_ADDED', 'CAT_UPDATED', 'CAT_DELETED', 'CAT_STATUS', 'CAT_MOVED',
+                'ART_ADDED', 'ART_UPDATED', 'ART_DELETED', 'ART_STATUS', 'ART_MOVED', 'ART_COPIED',
+                'ART_META_UPDATED', 'ART_TO_STARTARTICLE', 'ART_TO_CAT', 'CAT_TO_ART',
+                'CLANG_UPDATED',
+            ];
+            foreach ($extensionPoints as $extensionPoint) {
+                Extension::register($extensionPoint, static function (ExtensionPoint $ep): void {
+                    $params = $ep->getParams();
+                    $params['subject'] = $ep->subject;
+                    $params['extension_point'] = $ep->name;
+                    YRewrite::generatePathFile($params);
+                });
+            }
 
-                // per-article URL & SEO panels in the structure content sidebar
+            // Backend-only UI: per-article URL & SEO panels in the structure content sidebar.
+            if (Core::isBackend()) {
                 $user = Core::getUser();
                 if (!$this->getConfig('hide_url_block') && $user?->hasPerm('yrewrite[url]')) {
                     Extension::register('STRUCTURE_CONTENT_SIDEBAR', function (ExtensionPoint $ep): string {


### PR DESCRIPTION
> REDAXO-6-Variante von #623 (dort der Fix für `main` / REDAXO 5). Gleiche Ursache, gleiche Lösung — hier in `src/YRewriteAddon.php` statt `boot.php`.

## Problem

Die Listener, die den yrewrite-Pfad-Cache neu aufbauen (`ART_ADDED`, `CAT_ADDED`, `ART_STATUS`, `ART_UPDATED`, `ART_DELETED`, …), werden in `YRewriteAddon::boot()` **nur innerhalb von `if (Core::isBackend())`** registriert.

Struktur-Änderungen können aber auch **headless** ausgelöst werden — z. B. über das [`api`-AddOn](https://github.com/FriendsOfRedaxo/api), Console-Commands oder Cronjobs. Diese laufen im **Frontend-Kontext** (`Core::isBackend() === false`). Dort wird der Listener nie registriert: Der jeweilige EP feuert zwar, aber `YRewrite::generatePathFile()` läuft nicht.

**Folge:** Ein per API neu angelegter oder geänderter Artikel liefert im Frontend `404`, obwohl er online ist — bis der Cache manuell neu aufgebaut wird.

## Fix

Die Regenerierungs-Schleife wird **aus dem Backend-Guard herausgezogen** und damit in jedem Kontext registriert.

Ohne Overhead-Risiko: Die Extension Points feuern ausschließlich bei echten Struktur-Mutationen, **nicht** bei normalen Frontend-Seitenaufrufen.

Die rein backend-spezifischen Sidebar-Panels (URL & SEO im Struktur-Content) bleiben bewusst innerhalb von `if (Core::isBackend())`.

## Test

- Artikel/Kategorie via api-AddOn anlegen (oder per CLI/Cronjob) → URL ist sofort auflösbar, ohne manuellen Cache-Refresh.
- Normale Frontend-Requests: kein zusätzlicher Code-Pfad, da die Struktur-EPs dabei nicht feuern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)