### PR TITLE
getPathsByDomain(): Warning bei Domain ohne Pfade vermeiden

### DIFF
--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -212,7 +212,7 @@ class rex_yrewrite
 
     public static function getPathsByDomain($domain)
     {
-        return self::$paths['paths'][$domain];
+        return self::$paths['paths'][$domain] ?? [];
     }
 
     public static function prepare()


### PR DESCRIPTION
## Problem

`rex_yrewrite::getPathsByDomain($domain)` greift ungeguardet auf `self::$paths['paths'][$domain]` zu. Für Domains **ohne registrierte Pfade** existiert dieser Key nicht — insbesondere für die synthetische `'default'`-Domain, die yrewrite in `init()` immer anlegt und die in Multi-Domain-Setups keine eigenen Pfade hat.

Seit PHP 8.0 ist der Zugriff auf einen nicht existierenden Array-Key eine `E_WARNING` (vorher stilles `E_NOTICE`), daher:

```
Warning: Undefined array key "default" in .../lib/yrewrite/yrewrite.php on line 215
```

Das tritt z. B. auf, wenn man über `rex_yrewrite::getDomains()` iteriert (liefert die `'default'`-Domain mit) und pro Domain `getPathsByDomain()` aufruft. Auch `rex_yrewrite_seo` nutzt den Rückgabewert direkt in einem `foreach` und würde bei einer pfadlosen Domain warnen.

## Fix

Null-Coalescing auf ein leeres Array — analog zur Signatur, die im `3.x`-Zweig bereits so implementiert ist (`src/YRewrite.php`):

```php
return self::$paths['paths'][$domain] ?? [];
```

Damit gibt die Methode für unbekannte/pfadlose Domains ein leeres Array statt eines undefinierten Zugriffs zurück. Verhalten für existierende Domains bleibt unverändert; Aufrufer mit `if (!$paths)` bzw. direktem `foreach` funktionieren weiterhin.

## Kompatibilität

- Reiner Backport des `3.x`-Verhaltens auf `main`.
- Keine API- oder Verhaltensänderung für konfigurierte Domains.