### PR TITLE
Add per-domain option to force lowercase URLs (301 redirect)

### DIFF
--- a/install.php
+++ b/install.php
@@ -45,6 +45,7 @@ $table
     ->ensureColumn(new rex_sql_column('description', 'varchar(191)'))
     ->ensureColumn(new rex_sql_column('auto_redirect', 'tinyint(1)'))
     ->ensureColumn(new rex_sql_column('auto_redirect_days', 'int(3)'))
+    ->ensureColumn(new rex_sql_column('force_lowercase', 'tinyint(1)'))
     ->ensureIndex(new rex_sql_index('domain', ['domain'], rex_sql_index::UNIQUE))
     ->ensure();
 

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -185,6 +185,8 @@ yrewrite_auto_redirect = Automatische 301-Weiterleitungen setzen, wenn ein Artik
 yrewrite_auto_redirect_days = Anzahl Tage, bis automatische Weiterleitungen inaktiv werden.
 yrewrite_auto_redirect_days_info = <code>0</code> eintragen, um die automatische Deaktivierung auszuschalten.
 yrewrite_auto_redirects = Automatische Weiterleitungen
+yrewrite_force_lowercase = URLs immer in Kleinschreibung (301-Weiterleitung)
+yrewrite_force_lowercase_info = URLs mit Großbuchstaben werden per 301 auf die klein geschriebene Variante weitergeleitet. Vermeidet Duplicate Content. Prozent-kodierte Zeichen (z.&nbsp;B. Umlaute) bleiben unverändert.
 yrewrite_expiry_date = Deaktivierungsdatum
 
 perm_general_yrewrite[forward] = YRewrite: Weiterleitungen

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -183,6 +183,8 @@ yrewrite_auto_redirect = Send automatic 301 redirects when articles are renamed 
 yrewrite_auto_redirect_days = Number of days until automatic redirects are deactivated.
 yrewrite_auto_redirect_days_info = Enter 0 to disable automatic deactivation
 yrewrite_auto_redirects = Automatic redirects
+yrewrite_force_lowercase = Always lowercase URLs (301 redirect)
+yrewrite_force_lowercase_info = URLs containing uppercase letters are redirected (301) to their lowercase form. Prevents duplicate content. Percent-encoded characters (e.g. umlauts) are left untouched.
 yrewrite_expiry_date = Date of deactivation
 
 perm_general_yrewrite[forward] = YRewrite: Redirects

--- a/lib/yrewrite/domain.php
+++ b/lib/yrewrite/domain.php
@@ -29,8 +29,9 @@ class rex_yrewrite_domain
     private $robots;
     private $autoRedirect;
     private $autoRedirectDays;
+    private $forceLowercase;
 
-    public function __construct($name, $scheme, $path, $mountId, $startId, $notfoundId, ?array $clangs = null, $startClang = 1, $title = '', $description = '', $robots = '', $startClangHidden = false, $id = null, $autoRedirect = false, $autoRedirectDays = 0, $startClangAuto = false)
+    public function __construct($name, $scheme, $path, $mountId, $startId, $notfoundId, ?array $clangs = null, $startClang = 1, $title = '', $description = '', $robots = '', $startClangHidden = false, $id = null, $autoRedirect = false, $autoRedirectDays = 0, $startClangAuto = false, $forceLowercase = false)
     {
         $this->id = $id;
         $this->name = $name;
@@ -51,6 +52,7 @@ class rex_yrewrite_domain
         $this->robots = $robots;
         $this->autoRedirect = $autoRedirect;
         $this->autoRedirectDays = $autoRedirectDays;
+        $this->forceLowercase = $forceLowercase;
     }
 
     /**
@@ -195,6 +197,11 @@ class rex_yrewrite_domain
     public function getAutoRedirectDays()
     {
         return $this->autoRedirectDays;
+    }
+
+    public function isForceLowercase(): bool
+    {
+        return (bool) $this->forceLowercase;
     }
 
     public function __toString(): string

--- a/lib/yrewrite/path_resolver.php
+++ b/lib/yrewrite/path_resolver.php
@@ -62,6 +62,24 @@ class rex_yrewrite_path_resolver
             return;
         }
 
+        // force lowercase urls (seo duplicate content normalization)
+        // media (/media/...) and asset (/assets/...) requests never reach this resolver:
+        // media_manager intercepts rex_media_type on PACKAGES_INCLUDED (EARLY) and exits before
+        // rex_yrewrite::prepare() runs, and existing files are served directly by the web server.
+        // so media filenames (which are case-sensitive) are never lowercased here.
+        if ($domain->isForceLowercase()) {
+            // detect uppercase in a percent-encoding-safe way: strip %XX octets first, so encoded
+            // umlauts (e.g. "%C3%BC") do not trigger a spurious redirect.
+            $pathWithoutEscapes = preg_replace('/%[0-9A-Fa-f]{2}/', '', $url);
+            if (preg_match('/[A-Z]/', $pathWithoutEscapes)) {
+                // lowercase real ascii letters only, leave %XX escapes untouched.
+                $lowerUrl = preg_replace_callback('/%[0-9A-Fa-f]{2}|[A-Z]+/', static function ($m) {
+                    return '%' === $m[0][0] ? $m[0] : strtolower($m[0]);
+                }, $url);
+                $this->redirect($currentScheme . '://' . $host, $lowerUrl, $params);
+            }
+        }
+
         if (str_starts_with($url, $domain->getPath())) {
             $url = substr($url, strlen($domain->getPath()));
         }

--- a/lib/yrewrite/yrewrite.php
+++ b/lib/yrewrite/yrewrite.php
@@ -515,7 +515,8 @@ class rex_yrewrite
                     . $domain['id'] . ','
                     . $domain['auto_redirect'] . ','
                     . $domain['auto_redirect_days'] . ','
-                    . ($domain['clang_start_auto'] ? 'true' : 'false')
+                    . ($domain['clang_start_auto'] ? 'true' : 'false') . ','
+                    . ($domain['force_lowercase'] ? 'true' : 'false')
                     . '));';
             }
         }

--- a/pages/domains.php
+++ b/pages/domains.php
@@ -46,6 +46,7 @@ if ('' != $func) {
     $yform->setValueField('text', ['title_scheme', $this->i18n('domain_title_scheme'), rex_yrewrite_seo::$title_scheme_default, 'notice' => '<small>' . $this->i18n('domain_title_scheme_info') . '</small>']);
     $yform->setValueField('checkbox', ['auto_redirect', $this->i18n('auto_redirects'), 'notice' => '<small>' . $this->i18n('yrewrite_auto_redirect') . '</small>']);
     $yform->setValueField('text', ['auto_redirect_days', $this->i18n('yrewrite_auto_redirect_days'), 'notice' => '<small>' . $this->i18n('yrewrite_auto_redirect_days_info') . '</small>']);
+    $yform->setValueField('checkbox', ['force_lowercase', $this->i18n('force_lowercase'), 'notice' => '<small>' . $this->i18n('yrewrite_force_lowercase_info') . '</small>']);
 
     $js = '
         <script nonce="' . rex_response::getNonce() . '">
@@ -136,6 +137,7 @@ if ($showlist) {
     $list->removeColumn('id');
     $list->removeColumn('auto_redirect');
     $list->removeColumn('auto_redirect_days');
+    $list->removeColumn('force_lowercase');
 
     $list->setColumnLabel('domain', $this->i18n('domain'));
     $list->setColumnLabel('mount_id', $this->i18n('mount_id'));


### PR DESCRIPTION
## Problem

URLs that differ only in letter casing (`/Reisen/Afrika/` vs. `/reisen/afrika/`)
are treated as distinct URLs by search engines. When both variants are
reachable, this creates duplicate content and dilutes ranking signals. yrewrite
already normalizes several other aspects of an incoming URL via 301 redirects
(scheme, `www`/non-`www`, alias domains), but casing is not one of them.

## Solution

This PR adds a new **per-domain** boolean option **"Always lowercase URLs (301
redirect)"** (`force_lowercase`). When enabled for a domain, any frontend
request whose path contains uppercase ASCII letters is 301-redirected to its
lowercase form.

The enforcement lives in `rex_yrewrite_path_resolver::resolve()`, directly
after the existing `rex::isBackend()` guard and after the domain has been
resolved, and reuses the existing `redirect()` helper so it is a single hop and
consistent with the scheme/`www`/alias redirects already implemented there.

Casing detection and normalization are deliberately conservative:

- **Percent-encoding-safe detection**: `%XX` octets are stripped from the path
  *before* testing for `/[A-Z]/`, so an encoded umlaut such as `%C3%BC` never
  triggers a spurious redirect.
- **ASCII-only lowercasing**: only real ASCII `A–Z` runs are lowercased via
  `strtolower()`; `%XX` escape sequences and any non-ASCII (multibyte) bytes are
  left untouched.
- **No redirect loop**: after the redirect the path contains no uppercase ASCII,
  so the follow-up request does not re-trigger.
- **Query string preserved**: the resolver already carries `$params` through the
  `redirect()` helper.

### Media & assets are safe

Media (`/media/...`) and asset (`/assets/...`) requests never reach
`path_resolver::resolve()`:

- `media_manager` registers its handler on `PACKAGES_INCLUDED` with
  `rex_extension::EARLY` and `exit`s (`sendMedia()`) before
  `rex_yrewrite::prepare()` runs, so `/media/...` never reaches the resolver.
- Existing physical files (all of `/assets/...`) are served directly by the web
  server via the `!-f`/`!-d` rewrite conditions and never hit `index.php`.

Because case-sensitive media filenames can therefore never be lowercased, no
extra exclusion is needed in the resolver; a short comment documents this at the
insertion point.

## The new per-domain option

Implemented by mirroring the existing `auto_redirect` option end-to-end:

- `lib/yrewrite/domain.php`: private `$forceLowercase` property, constructor
  argument (appended at the very end), and an `isForceLowercase(): bool` getter.
- `lib/yrewrite/yrewrite.php`: the domain config generator reads the new
  `force_lowercase` column and passes it as the last positional argument.
- `install.php`: the `force_lowercase` column is added via the same
  `ensureColumn(new rex_sql_column(...))` mechanism as `auto_redirect`
  (idempotent, also runs on update because `update.php` requires `install.php`).
- `pages/domains.php`: a checkbox in the domain edit form (saved automatically
  by the existing YForm `db` action) and a corresponding `removeColumn()` in the
  domain list.
- `lang/de_de.lang`, `lang/en_gb.lang`: label + description keys
  (`yrewrite_force_lowercase`, `yrewrite_force_lowercase_info`).

## Backward compatibility

- The new constructor argument `$forceLowercase = false` is **appended at the
  end** of the parameter list, preserving all existing positional calls.
- The `force_lowercase` column is added **idempotently** and defaults to `0`.
- The option defaults to **off**, so existing installations see **no behavior
  change** until an editor explicitly enables it per domain.

## Testing

- `php -l` is clean on every changed file, and the REDAXO PHP-CS-Fixer config
  reports no style changes.
- The lowercase transform was verified against representative paths:
  `/Reisen/Afrika/` → `/reisen/afrika/`; already-lowercase paths and
  purely numeric paths produce no redirect; `%C3%BC` (encoded umlaut) does not
  trigger a redirect; mixed paths like `/PATH/%2Fmixed/ABC` become
  `/path/%2Fmixed/abc` with the `%2F` escape preserved; raw multibyte characters
  pass through unchanged.
- Manual check recommended on a live install: enable the option for a domain,
  request a URL with mixed casing, confirm a single 301 to the lowercase URL
  with the query string preserved, and confirm `/media/...` and `/assets/...`
  URLs are unaffected.
